### PR TITLE
Add build and release action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,102 @@
+name: Build Sage Executables
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  release:
+    types: [ created ]
+
+jobs:
+  build_ubuntu:
+    name: Build Sage for Linux
+    runs-on: ubuntu-latest
+    container: ubuntu:14.04 # GLIBC 2.19
+    steps:
+    - name: Install dependencies
+      run: |
+        sudo apt-get update && sudo apt-get upgrade -y
+        sudo apt-get install -y curl build-essential
+
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Get Cargo toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+
+    - name: Build Sage
+      uses: actions-rs/cargo@v1
+      with:
+        command: build
+        args: --release
+
+    - name: Upload executable to release
+      uses: ./.github/workflows/upload_artifacts
+      with:
+        name: Linux 64-bit
+        token: ${{ secrets.GITHUB_TOKEN }}
+
+
+  build_windows:
+    name: Build Sage for Windows
+    runs-on: windows-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Get Cargo toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+
+    - name: Build Sage
+      uses: actions-rs/cargo@v1
+      with:
+        command: build
+        args: --release
+
+    - name: Upload executable to release
+      uses: ./.github/workflows/upload_artifacts
+      with:
+        name: Windows 64-bit
+        token: ${{ secrets.GITHUB_TOKEN }}
+        path: target/release/sage.exe
+
+
+  build_macos:
+    name: Build Sage for MacOS
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-apple-darwin
+            name: MacOS (Intel)
+          - target: aarch64-apple-darwin
+            name: MacOS (Apple Silicon)
+
+    runs-on: macos-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Get Cargo toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        target: ${{ matrix.target }}
+        override: true
+
+    - name: Build Sage
+      uses: actions-rs/cargo@v1
+      with:
+        command: build
+        args: --release --target ${{ matrix.target }}
+
+    - name: Upload to Release
+      uses: ./.github/workflows/upload_artifacts
+      with:
+        name: ${{ matrix.name }}
+        token: ${{ secrets.GITHUB_TOKEN }}
+        path: target/${{ matrix.target }}/release/sage

--- a/.github/workflows/upload_artifacts/action.yml
+++ b/.github/workflows/upload_artifacts/action.yml
@@ -1,0 +1,34 @@
+name: Upload Artifacts
+description: Upload the Sage executable artifacts.
+
+inputs:
+  name:
+    required: true
+    type: string
+  token:
+    required: true
+    type: string
+  path:
+    required: false
+    type: string
+    default: target/release/sage
+
+runs:
+  using: "composite"
+  steps:
+
+  - name: Upload build artifacts
+    uses: actions/upload-artifact@v3
+    with:
+      name: ${{ inputs.name }}
+      path: ${{ inputs.path }}
+
+  - name: Upload artifacts to the release
+    uses: svenstaro/upload-release-action@v2
+    if: ${{ github.event_name == 'release' }}
+    with:
+      repo_token: ${{ inputs.token }}
+      tag: ${{ github.ref }}
+      asset_name: ${{ inputs.name  }}
+      file: ${{ inputs.path }}
+      overwrite: true


### PR DESCRIPTION
This PR adds a GitHub workflow to build Sage on:

- Linux x86_64 (using Ubuntu 14.04)
- Windows x86_64
- MacOS x86_64
- MacOS aarch64 (for Apple Silicon)

The builds are triggered on new PRs and commits to master, and the executables are uploaded as artifacts automatically for manual inspection, if desired.

New GitHub releases trigger this workflow and additionally the executables will be automatically uploaded as assets to the new release. 