### PR TITLE
Add a Sage Docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -48,7 +48,7 @@ jobs:
         images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
     - name: Push the Docker image to the GHCR
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
         push: false
         platforms: linux/amd64,linux/arm64,darwin/amd64,darwin/arm64,windows/amd64

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -57,6 +57,6 @@ jobs:
       uses: docker/build-push-action@v3
       with:
         push: false
-        platforms: linux/amd64,linux/arm64,darwin/amd64,darwin/arm64,windows/amd64
+        platforms: linux/amd64,linux/arm64
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,56 @@
+name: Build Docker image
+
+on:
+  push:
+    #branches: [master]
+  release:
+    types: [published, edited]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: lazear/sage
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout the repository
+      uses: actions/checkout@v3
+
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Get Cargo toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        target: x86_64-unknown-linux-musl
+        override: true
+
+    - name: Build Sage
+      uses: actions-rs/cargo@v1
+      with:
+        use-cross: true
+        command: build
+        args: --release --target x86_64-unknown-linux-musl
+
+    - name: Login to the GitHub Container Registry
+      uses: docker/login-action@v1
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Extract metadata for Docker
+      id: meta
+      uses: docker/metadata-action@v3
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+    - name: Push the Docker image to the GHCR
+      uses: docker/build-push-action@v2
+      with:
+        push: false
+        platforms: linux/amd64,linux/arm64,darwin/amd64,darwin/arm64,windows/amd64
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -58,9 +58,3 @@ jobs:
         platforms: linux/amd64,linux/arm64
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
-
-    - name: Upload Docker image as artifact
-      uses: actions/upload-artifact@v3
-      with:
-        name: docker-image
-        path: /tmp/sage.tar

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,9 +17,6 @@ jobs:
     - name: Checkout the repository
       uses: actions/checkout@v3
 
-    - name: Checkout repository
-      uses: actions/checkout@v3
-
     - name: Get Cargo toolchain
       uses: actions-rs/toolchain@v1
       with:
@@ -61,3 +58,9 @@ jobs:
         platforms: linux/amd64,linux/arm64
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
+
+    - name: Upload Docker image as artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: docker-image
+        path: /tmp/sage.tar

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,7 +18,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Get Cargo toolchain
       uses: actions-rs/toolchain@v1
@@ -33,6 +33,12 @@ jobs:
         use-cross: true
         command: build
         args: --release --target x86_64-unknown-linux-musl
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
 
     - name: Login to the GitHub Container Registry
       uses: docker/login-action@v1

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,7 @@ name: Build Docker image
 
 on:
   push:
-    #branches: [master]
+    branches: [master]
   release:
     types: [published, edited]
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -56,6 +56,7 @@ jobs:
     - name: Push the Docker image to the GHCR
       uses: docker/build-push-action@v3
       with:
+        context: .
         push: false
         platforms: linux/amd64,linux/arm64
         tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM alpine:latest
+
+WORKDIR /app
+
+COPY target/x86_64-unknown-linux-musl/release/sage ./sage
+
+ENV PATH="/app:$PATH"


### PR DESCRIPTION
This PR adds a Github workflow to build an Alpine-based Docker image for Sage.

Docker images are build with each commit to master (should have the `master` tag), and on new releases (should have the release tag). I've configured it to upload the images to the [Github Container Registry](https://github.com/features/packages), but it can be easily configured to upload to Dockerhub, AWS ECR, etc.

The image is multiplatform, covering x86_64 and arm64 architectures on Linux.