### PR TITLE
Specify some parameters from the CLI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,3 +22,14 @@ jobs:
       run: cargo test --verbose
     - name: Run VAT1_HUMAN search
       run: cargo run tests/config.json
+    - name: Run with CLI args
+      run: |
+        cargo run -- \
+          -f tests/Q99536.fasta \
+          -o foo \
+          tests/config-cli.json \
+          tests/*.mzML
+        if [ ! - LQSRPAAPPAPGPGQLTLR.sage.pin ]; then
+          echo "FILE NOT FOUND!"
+          exit 1
+        fi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT"
 [dependencies]
 base64 = "0.13"
 csv = "1"
-clap = "3.2"
+clap = { version="4.0", features = ["cargo", "unicode"] }
 env_logger = "0.8.4"
 log = "0.4.0"
 miniz_oxide = "0.5.3"

--- a/src/bin/sage.rs
+++ b/src/bin/sage.rs
@@ -48,7 +48,7 @@ struct Input {
     quant: Option<Isobaric>,
     predict_rt: Option<bool>,
     output_directory: Option<PathBuf>,
-    mzml_paths: Vec<PathBuf>,
+    mzml_paths: Option<Vec<PathBuf>>,
 }
 
 impl Search {
@@ -70,7 +70,7 @@ impl Search {
         }
         let mzml_paths = match mzml_paths {
             Some(p) => p.into_iter().map(|f| f.as_ref().to_path_buf()).collect(),
-            _ => request.mzml_paths,
+            _ => request.mzml_paths.expect("'mzml_paths' must be provided!"),
         };
 
         let output_directory = match output_directory {

--- a/src/bin/sage.rs
+++ b/src/bin/sage.rs
@@ -52,16 +52,40 @@ struct Input {
 }
 
 impl Search {
-    pub fn load<P: AsRef<Path>>(path: P) -> Result<Self, Box<dyn std::error::Error>> {
+    pub fn load<P: AsRef<Path>>(
+        path: P,
+        mzml_paths: Option<Vec<P>>,
+        fasta: Option<P>,
+        output_directory: Option<P>
+    ) -> Result<Self, Box<dyn std::error::Error>> {
         let mut file = std::fs::File::open(path)?;
-        let request: Input = serde_json::from_reader(&mut file)?;
+        let mut request: Input = serde_json::from_reader(&mut file)?;
+        if let Some(f) = fasta {
+            request.database.update_fasta(f.as_ref().to_path_buf())
+        };
         let database = request.database.make_parameters();
         let isotope_errors = request.isotope_errors.unwrap_or((0, 0));
         if isotope_errors.0 > isotope_errors.1 {
             log::warn!("Minimum isotope_error value greater than maximum! Typical usage: `isotope_errors: [-1, 3]`");
         }
+        let mzml_paths = match mzml_paths {
+            Some(p) => {
+                p.into_iter()
+                 .map(|f| f.as_ref().to_path_buf())
+                 .collect()
+            },
+            _ => request.mzml_paths,
+        };
+
+        let output_directory = match output_directory {
+            Some(p) => Some(p.as_ref().to_path_buf()),
+            _ => request.output_directory,
+        };
+
         Ok(Search {
             database,
+            mzml_paths,
+            output_directory,
             quant: request.quant,
             precursor_tol: request.precursor_tol,
             fragment_tol: request.fragment_tol,
@@ -74,8 +98,6 @@ impl Search {
             chimera: request.chimera.unwrap_or(false),
             predict_rt: request.predict_rt.unwrap_or(true),
             pin_paths: Vec::new(),
-            mzml_paths: request.mzml_paths,
-            output_directory: request.output_directory,
             search_time: 0.0,
         })
     }
@@ -228,14 +250,57 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let start = time::Instant::now();
 
     let matches = Command::new("sage")
+        .version(clap::crate_version!())
         .author("Michael Lazear <michaellazear92@gmail.com>")
-        .arg(Arg::new("parameters").required(true))
+        .about("\u{1F52E} Sage \u{1F9D9} - Proteomics searching so fast it feels like magic!")
+        .arg(
+            Arg::new("parameters")
+                .required(true)
+                .help("The search parameters as a JSON file.")
+        )
+        .arg(
+            Arg::new("mzml_paths")
+                .num_args(1..)
+                .help(
+                    "mzML files to analyze. Overrides mzML files listed in the \
+                     parameter file."
+                )
+        )
+        .arg(
+            Arg::new("fasta")
+                .short('f')
+                .long("fasta")
+                .help(
+                    "The FASTA protein database. Overrides the FASTA file \
+                     specified in the parameter file."
+                )
+        )
+        .arg(
+            Arg::new("output_directory")
+                .short('o')
+                .long("output_directory")
+                .help(
+                    "Where the search and quant results will be written. \
+                     Overrides the directory specified in the parameter file."
+                )
+        )
+        .help_template(
+            "{usage-heading} {usage}\n\n\
+             {about-with-newline}\n\
+             Written by {author-with-newline}Version {version}\n\n\
+             {all-args}{after-help}"
+        )
         .get_matches();
 
     let path = matches
         .get_one::<String>("parameters")
         .expect("required parameters");
-    let mut search = Search::load(path)?;
+    let output_directory = matches.get_one::<String>("output_directory");
+    let fasta = matches.get_one::<String>("fasta");
+    let mzml_paths = matches.get_many::<String>("mzml_paths")
+        .map(|vals| vals.collect());
+
+    let mut search = Search::load(path, mzml_paths, fasta, output_directory)?;
 
     let db = search.database.clone().build()?;
 

--- a/src/bin/sage.rs
+++ b/src/bin/sage.rs
@@ -56,7 +56,7 @@ impl Search {
         path: P,
         mzml_paths: Option<Vec<P>>,
         fasta: Option<P>,
-        output_directory: Option<P>
+        output_directory: Option<P>,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let mut file = std::fs::File::open(path)?;
         let mut request: Input = serde_json::from_reader(&mut file)?;
@@ -69,11 +69,7 @@ impl Search {
             log::warn!("Minimum isotope_error value greater than maximum! Typical usage: `isotope_errors: [-1, 3]`");
         }
         let mzml_paths = match mzml_paths {
-            Some(p) => {
-                p.into_iter()
-                 .map(|f| f.as_ref().to_path_buf())
-                 .collect()
-            },
+            Some(p) => p.into_iter().map(|f| f.as_ref().to_path_buf()).collect(),
             _ => request.mzml_paths,
         };
 
@@ -256,39 +252,30 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .arg(
             Arg::new("parameters")
                 .required(true)
-                .help("The search parameters as a JSON file.")
+                .help("The search parameters as a JSON file."),
         )
-        .arg(
-            Arg::new("mzml_paths")
-                .num_args(1..)
-                .help(
-                    "mzML files to analyze. Overrides mzML files listed in the \
-                     parameter file."
-                )
-        )
-        .arg(
-            Arg::new("fasta")
-                .short('f')
-                .long("fasta")
-                .help(
-                    "The FASTA protein database. Overrides the FASTA file \
-                     specified in the parameter file."
-                )
-        )
+        .arg(Arg::new("mzml_paths").num_args(1..).help(
+            "mzML files to analyze. Overrides mzML files listed in the \
+                     parameter file.",
+        ))
+        .arg(Arg::new("fasta").short('f').long("fasta").help(
+            "The FASTA protein database. Overrides the FASTA file \
+                     specified in the parameter file.",
+        ))
         .arg(
             Arg::new("output_directory")
                 .short('o')
                 .long("output_directory")
                 .help(
                     "Where the search and quant results will be written. \
-                     Overrides the directory specified in the parameter file."
-                )
+                     Overrides the directory specified in the parameter file.",
+                ),
         )
         .help_template(
             "{usage-heading} {usage}\n\n\
              {about-with-newline}\n\
              Written by {author-with-newline}Version {version}\n\n\
-             {all-args}{after-help}"
+             {all-args}{after-help}",
         )
         .get_matches();
 
@@ -297,7 +284,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .expect("required parameters");
     let output_directory = matches.get_one::<String>("output_directory");
     let fasta = matches.get_one::<String>("fasta");
-    let mzml_paths = matches.get_many::<String>("mzml_paths")
+    let mzml_paths = matches
+        .get_many::<String>("mzml_paths")
         .map(|vals| vals.collect());
 
     let mut search = Search::load(path, mzml_paths, fasta, output_directory)?;

--- a/src/database.rs
+++ b/src/database.rs
@@ -39,7 +39,7 @@ pub struct Builder {
     /// Use this prefix for decoy proteins
     pub decoy_prefix: Option<String>,
     /// Path to fasta database
-    pub fasta: PathBuf,
+    pub fasta: Option<PathBuf>,
 }
 
 impl Builder {
@@ -75,12 +75,12 @@ impl Builder {
             missed_cleavages: self.missed_cleavages.unwrap_or(0),
             static_mods: Self::validate_mods(self.static_mods),
             variable_mods: Self::validate_mods(self.variable_mods),
-            fasta: self.fasta,
+            fasta: self.fasta.expect("A fasta file must be provided!"),
         }
     }
 
     pub fn update_fasta(&mut self, fasta: PathBuf) {
-        self.fasta = fasta
+        self.fasta = Some(fasta)
     }
 }
 

--- a/src/database.rs
+++ b/src/database.rs
@@ -78,6 +78,10 @@ impl Builder {
             fasta: self.fasta,
         }
     }
+
+    pub fn update_fasta(&mut self, fasta: PathBuf) {
+        self.fasta = fasta
+    }
 }
 
 #[derive(Serialize, Clone, Debug)]

--- a/tests/config-cli.json
+++ b/tests/config-cli.json
@@ -1,0 +1,33 @@
+{
+    "database": {
+        "bucket_size": 16384,
+        "fragment_min_mz": 150.0,
+        "fragment_max_mz": 1500.0,
+        "peptide_max_mass": 5000.0,
+        "missed_cleavages": 1,
+        "static_mods": {
+            "C": 57.0216
+        },
+        "decoy_prefix": "rev_"
+    },
+    "deisotope": true,
+    "chimera": false,
+    "max_fragment_charge": 1,
+    "report_psms": 1,
+    "precursor_tol": {
+        "ppm": [
+            -50,
+            50
+        ]
+    },
+    "fragment_tol": {
+        "ppm": [
+            -10,
+            10
+        ]
+    },
+    "isotope_errors": [
+        -1,
+        3
+    ]
+}


### PR DESCRIPTION
This PR adds some parameters to the CLI, which overide the configuration provided in the param file. The included parameters are:

- `mzml_paths`
- `database.fasta`
- `output_directory`

This makes it easier to construct a default config file and use it for many analyses. Now you can run:
```sh
# Only with config file:
sage config.json

# specify fasta and output dir:
sage -f proteins.fasta -o cool_project config.json

# And specify mzML files:
sage -f proteins.fasta config.json *.mzML
```

I didn't write tests... mostly because I don't know how to test a Rust CLI yet.

*Please note that I just finished reading the Rust book this weekend, so certainly no offense if there's a lot of changes to make.* 😆 