### PR TITLE
Added bash to Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM alpine:latest
 
+RUN apk add --no-cache bash
+
 WORKDIR /app
 
 COPY target/x86_64-unknown-linux-musl/release/sage ./sage


### PR DESCRIPTION
This PR just adds Bash to the Docker image, which is a prerequisite for NextFlow containers. I think it only adds ~1MB to the image size.