### PR TITLE
Update readme to mention the github releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,10 @@ Sage has excellent performance characteristics (5x faster than - the closed sour
 
 # Installation
 
-## Installing the development version
+There is no need to install sage, it is distributed as a standalone executable file.
+This file can be either built directly from the github repository or downloaded
+from a pre-compiled release
+## Compiling the development version
 
 1. Install the [Rust programming language compiler](https://rustup.rs/)
 2. Download Sage source code via git: `git clone https://github.com/lazear/sage.git` or by [zip file](https://github.com/lazear/sage/archive/refs/heads/master.zip)
@@ -58,7 +61,7 @@ cd sage
 cargo run --release tests/config.json 
 ```
 
-## Installing the latest release
+## Downloading the latest release
 
 1. Visit the [Releases](https://github.com/lazear/sage/releases/latest) website.
 2. Download the correct pre-compiled binary for your operating system.
@@ -102,7 +105,7 @@ like so ...
 
 ```
 # specify fasta and output dir:
-sage -f proteins.fasta -o cool_project config.json
+sage -f proteins.fasta -o output_directory config.json
 
 # And specify mzML files:
 sage -f proteins.fasta config.json *.mzML
@@ -120,7 +123,7 @@ Two notes:
 - Tolerances are specified on the *experimental* m/z values. To perform a -100 to +500 Da open search (mass window applied to *precursor*), you would use `"da": [-500, 100]`
 
 ```jsonc
-// Note that json does not allow comments, they are here just as explaination
+// Note that json does not allow comments, they are here just as explanation
 // but need to be removed in a real config.json file
 {
   "database": {

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Sage has excellent performance characteristics (5x faster than - the closed sour
 
 # Installation
 
+## Installing the development version
+
 1. Install the [Rust programming language compiler](https://rustup.rs/)
 2. Download Sage source code via git: `git clone https://github.com/lazear/sage.git` or by [zip file](https://github.com/lazear/sage/archive/refs/heads/master.zip)
 3. Compile: `cargo build --release`
@@ -55,6 +57,12 @@ git clone https://github.com/lazear/sage.git
 cd sage
 cargo run --release tests/config.json 
 ```
+
+## Installing the latest release
+
+1. Visit the [Releases](https://github.com/lazear/sage/releases/latest) website.
+2. Download the correct pre-compiled binary for your operating system.
+3. Run: `local/location/of/the/executable/sage config.json`
 
 # Usage 
 

--- a/README.md
+++ b/README.md
@@ -66,9 +66,47 @@ cargo run --release tests/config.json
 
 # Usage 
 
-Sage takes a single command line argument: a path to a JSON-encoded parameter file (see below). 
+```shell
+$ sage --help
+Usage: sage [OPTIONS] <parameters> [mzml_paths]...
+
+🔮 Sage 🧙 - Proteomics searching so fast it feels like magic!
+
+Arguments:
+  <parameters>     The search parameters as a JSON file.
+  [mzml_paths]...  mzML files to analyze. Overrides mzML files listed in the parameter file.
+
+Options:
+  -f, --fasta <fasta>
+          The FASTA protein database. Overrides the FASTA file specified in the parameter file.
+  -o, --output_directory <output_directory>
+          Where the search and quant results will be written. Overrides the directory specified in the parameter file.
+  -h, --help
+          Print help information
+  -V, --version
+          Print version information
+```
+
+Sage is called from the command line using and requires a path to a JSON-encoded parameter file as an argument (see below). 
 
 Example usage: `sage config.json`
+
+Some options in the parameters file can be over-written using the command line
+interface. These are:
+
+1. The paths to the raw mzML data
+2. The path to the database (fasta file)
+3. The output directory
+
+like so ...
+
+```
+# specify fasta and output dir:
+sage -f proteins.fasta -o cool_project config.json
+
+# And specify mzML files:
+sage -f proteins.fasta config.json *.mzML
+```
 
 Running Sage will produce several output files:
 - Record of search parameters (`results.json`) will be created that details input/output paths and all search parameters used for the search
@@ -82,6 +120,8 @@ Two notes:
 - Tolerances are specified on the *experimental* m/z values. To perform a -100 to +500 Da open search (mass window applied to *precursor*), you would use `"da": [-500, 100]`
 
 ```jsonc
+// Note that json does not allow comments, they are here just as explaination
+// but need to be removed in a real config.json file
 {
   "database": {
     "bucket_size": 32768,           // How many fragments are in each internal mass bucket

--- a/README.md
+++ b/README.md
@@ -171,3 +171,17 @@ Two notes:
   "mzml_paths": ["path.mzML"]       // List[str]: representing relative (or full) paths to mzML files for search
 }
 ```
+
+## Using the docker image
+
+Sage can be used from a docker image!
+
+```shell
+$ docker pull ghcr.io/lazear/sage:master
+$ docker run -it --rm -v ${PWD}:/data ghcr.io/lazear/sage:master sage -o /data /data/config.json
+# The sage executable is located in /app/sage in the image
+```
+
+> `-v ${PWD}:/data` means it will mount your current directory as `/data`
+> in the docker image. Make sure all the paths in your command and configuration
+> use the location in the image and not your local directory


### PR DESCRIPTION
Hello there!

First off, I am very impressed by the project so I wanted to make a minor contribution to the documentation. I added "installation" instructions for the pre-compiled binaries in the github releases.

In an additional effort to improve documentation:

-  On the "notes" you also mention:
    > - The majority of parameters are optional - only "database.fasta", "precursor_tol", and "fragment_tol" are required. Sage will try and use reasonable defaults for any parameters not supplied
    
    I am assuming that means reasonable for data-dependent narrow-window high-resolution ms2 runs, right? Should that be explicit?

- Should a page be added to explain all the features used internally for re-scoring?

- [x] Document the change in CLI that allows over-writting the json
https://github.com/lazear/sage/pull/19
- [x] Document docker image usage (https://github.com/lazear/sage/pull/18) -> docker pull ghcr.io/lazear/sage:master

Thanks a lot for the great project!
Sebastian