### PR TITLE
update CI to compress binaries in archive at release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,102 +1,141 @@
 name: Build Sage Executables
 
 on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
   release:
-    types: [ created ]
+    types: [created]
 
 jobs:
   build_ubuntu:
     name: Build Sage for Linux
     runs-on: ubuntu-latest
     container: ubuntu:14.04 # GLIBC 2.19
+    strategy:
+      matrix:
+        include:
+          - name: Linux 64-bit
+            target: x86_64-unknown-linux-musl
+
     steps:
-    - name: Install dependencies
-      run: |
-        sudo apt-get update && sudo apt-get upgrade -y
-        sudo apt-get install -y curl build-essential
+      - name: Install dependencies
+        run: |
+          sudo apt-get update && sudo apt-get upgrade -y
+          sudo apt-get install -y curl build-essential
 
-    - name: Checkout repository
-      uses: actions/checkout@v2
+      - name: Checkout repository
+        uses: actions/checkout@v3
 
-    - name: Get Cargo toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
+      - name: Get Cargo toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: ${{ matrix.target }}
 
-    - name: Build Sage
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        args: --release
+      - name: Build Sage
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --target ${{ matrix.target }}
 
-    - name: Upload executable to release
-      uses: ./.github/workflows/upload_artifacts
-      with:
-        name: Linux 64-bit
-        token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build archive
+        shell: bash
+        run: |
+          sage_version=${{ github.ref_name }}
+          staging="sage-$sage_version-${{ matrix.target }}"
+          mkdir -p "$staging"
+          cp "target/${{ matrix.target }}/release/sage" "$staging/"
+          tar czf "$staging.tar.gz" "$staging"
+          echo "ASSET=$staging.tar.gz" >> $GITHUB_ENV
 
+      - name: Upload executable to release
+        uses: ./.github/workflows/upload_artifacts
+        with:
+          name: ${{ env.ASSET }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          path: ${{ env.ASSET }}
 
   build_windows:
     name: Build Sage for Windows
     runs-on: windows-latest
+    strategy:
+      matrix:
+        include:
+          - name: Windows 64-bits
+            target: x86_64-pc-windows-msvc
+
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
+      - name: Checkout repository
+        uses: actions/checkout@v3
 
-    - name: Get Cargo toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
+      - name: Get Cargo toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: ${{ matrix.target }}
 
-    - name: Build Sage
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        args: --release
+      - name: Build Sage
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --target ${{ matrix.target }}
 
-    - name: Upload executable to release
-      uses: ./.github/workflows/upload_artifacts
-      with:
-        name: Windows 64-bit
-        token: ${{ secrets.GITHUB_TOKEN }}
-        path: target/release/sage.exe
+      - name: Build archive
+        shell: bash
+        run: |
+          sage_version=${{ github.ref_name }} 
+          staging="sage-$sage_version-${{ matrix.target }}"
+          mkdir -p "$staging"
+          cp "target/${{ matrix.target }}/release/sage.exe" "$staging/"
+          7z a "$staging.zip" "$staging"
+          echo "ASSET=$staging.zip" >> $GITHUB_ENV
 
+      - name: Upload executable to release
+        uses: ./.github/workflows/upload_artifacts
+        with:
+          name: ${{ env.ASSET }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          path: ${{ env.ASSET }}
 
   build_macos:
     name: Build Sage for MacOS
     strategy:
       matrix:
         include:
-          - target: x86_64-apple-darwin
-            name: MacOS (Intel)
-          - target: aarch64-apple-darwin
-            name: MacOS (Apple Silicon)
+          - name: MacOS (Intel)
+            target: x86_64-apple-darwin
+          - name: MacOS (Apple Silicon)
+            target: aarch64-apple-darwin
 
     runs-on: macos-latest
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
+      - name: Checkout repository
+        uses: actions/checkout@v3
 
-    - name: Get Cargo toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        target: ${{ matrix.target }}
-        override: true
+      - name: Get Cargo toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: ${{ matrix.target }}
+          override: true
 
-    - name: Build Sage
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        args: --release --target ${{ matrix.target }}
+      - name: Build Sage
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --target ${{ matrix.target }}
 
-    - name: Upload to Release
-      uses: ./.github/workflows/upload_artifacts
-      with:
-        name: ${{ matrix.name }}
-        token: ${{ secrets.GITHUB_TOKEN }}
-        path: target/${{ matrix.target }}/release/sage
+      - name: Build archive
+        shell: bash
+        run: |
+          sage_version=${{ github.ref_name }} 
+          staging="sage-$sage_version-${{ matrix.target }}"
+          mkdir -p "$staging"
+          cp "target/${{ matrix.target }}/release/sage" "$staging/"
+          tar czf "$staging.tar.gz" "$staging"
+          echo "ASSET=$staging.tar.gz" >> $GITHUB_ENV
+
+      - name: Upload to Release
+        uses: ./.github/workflows/upload_artifacts
+        with:
+          name: $${{ env.ASSET }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          path: ${{ env.ASSET }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,7 @@ jobs:
           sage_version=${{ github.ref_name }}
           staging="sage-$sage_version-${{ matrix.target }}"
           mkdir -p "$staging"
+          cp {README.md,LICENSE} "$staging/"
           cp "target/${{ matrix.target }}/release/sage" "$staging/"
           tar czf "$staging.tar.gz" "$staging"
           echo "ASSET=$staging.tar.gz" >> $GITHUB_ENV
@@ -84,6 +85,7 @@ jobs:
           sage_version=${{ github.ref_name }} 
           staging="sage-$sage_version-${{ matrix.target }}"
           mkdir -p "$staging"
+          cp {README.md,LICENSE} "$staging/"
           cp "target/${{ matrix.target }}/release/sage.exe" "$staging/"
           7z a "$staging.zip" "$staging"
           echo "ASSET=$staging.zip" >> $GITHUB_ENV
@@ -129,6 +131,7 @@ jobs:
           sage_version=${{ github.ref_name }} 
           staging="sage-$sage_version-${{ matrix.target }}"
           mkdir -p "$staging"
+          cp {README.md,LICENSE} "$staging/"
           cp "target/${{ matrix.target }}/release/sage" "$staging/"
           tar czf "$staging.tar.gz" "$staging"
           echo "ASSET=$staging.tar.gz" >> $GITHUB_ENV

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,8 +1,6 @@
 name: Build Docker image
 
 on:
-  push:
-    branches: [master]
   release:
     types: [published, edited]
 
@@ -14,47 +12,47 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout the repository
-      uses: actions/checkout@v3
+      - name: Checkout the repository
+        uses: actions/checkout@v3
 
-    - name: Get Cargo toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        target: x86_64-unknown-linux-musl
-        override: true
+      - name: Get Cargo toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: x86_64-unknown-linux-musl
+          override: true
 
-    - name: Build Sage
-      uses: actions-rs/cargo@v1
-      with:
-        use-cross: true
-        command: build
-        args: --release --target x86_64-unknown-linux-musl
+      - name: Build Sage
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: build
+          args: --release --target x86_64-unknown-linux-musl
 
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
 
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
 
-    - name: Login to the GitHub Container Registry
-      uses: docker/login-action@v1
-      with:
-        registry: ${{ env.REGISTRY }}
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Login to the GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Extract metadata for Docker
-      id: meta
-      uses: docker/metadata-action@v3
-      with:
-        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
-    - name: Push the Docker image to the GHCR
-      uses: docker/build-push-action@v3
-      with:
-        context: .
-        push: true
-        platforms: linux/amd64,linux/arm64
-        tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
+      - name: Push the Docker image to the GHCR
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
I adapted the CI configuration from ripgrep https://github.com/BurntSushi/ripgrep/blob/master/.github/workflows/release.yml and kept the structure of the existing configuration.

- binaries are named `sage` (`sage.exe` on Windows) 
- binaries are compressed in `tar.gz` (or `zip` on Windows) archives named like `sage-[version]-[target].tar.gz`  (Fixes #23)
- refactor Linux and Windows job like the MacOS one using matrix for consistency and to allow further extension of the matrices, or merge of the 3 jobs eventually
- `Build Sage Executables` and `Build Docker image` now only run on releases not on every push to master
- whitespace changes due to my format on save make it look like I changed a lot :(

