### PR TITLE
Keep track of spectrum nativeIDs, rather than scan number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rename `pin_paths` to `output_paths` in results.json file
 
 
-## [0.5.0] - 2022-10-28
+## [0.5.1] - 2022-10-31
 ### Added
 - Support for selenocysteine and pyrrolysine amino acids
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,55 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+<!-- ## [Unreleased] -->
+
+
+## [0.6.0] - 2022-11-01
+## Added
+- Changelog
+- `rank` column added to output file
+- `database.generate_decoys` parameter, which turns off internal decoy generation. This enables the use of FASTA databases for SearchGUI/PeptideShaker
+
+### Changed
+- Base ProForma v2 notation is used for peptide modifications, i.e. "\[+304.2071\]-PEPTIDEM\[+15.9949\]AAC\[+57.0214\]H"
+- `scannr` column now contains the full nativeID/spectrum title from the mzML file, i.e. "controllerType=0 controllerNumber=1 scan=30069"
+- `discriminant_score` column renamed to `sage_discriminant_score` for PeptideShaker recognition
+- `database.decoy_prefix` JSON option changed to `database.decoy_tag`. This allows decoy tagging to occur anywhere within the accession: "sp|P01234_REVERSED|HUMAN"
+- Output file renamed:  `results.pin` to `results.sage.tsv`
+- Output file renamed: `quant.csv` to `quant.tsv`
+- Rename `pin_paths` to `output_paths` in results.json file
+
+
+## [0.5.0] - 2022-10-28
+### Added
+- Support for selenocysteine and pyrrolysine amino acids
+
+## [0.5.0] - 2022-10-28
+### Added
+- Ability to directly read/write files from AWS S3
+
+### Changed
+- Processing files in parallel processes them in batches of `num_cpus / 2` to avoid memory issues
+- Fixed bug where `protein_fdr` was erroneously assigned to `peptide_fdr` output field
+- Additional parallelization for assignment of PEP, FDR, writing output files
+
+## [0.4.0] - 2022-10-18
+### Added
+- Label free quantification can be enabled by turning on `quant.lfq` JSON parameter 
+- Commmand line arguments can be used to override configuration file
+
+## [0.3.1] - 2022-10-06
+### Added
+- Workflow contributions from [@wfondrie](https://github.com/wfondrie).
+
+### Changed
+- Don't parse empty MS2 spectra
+
+## [0.3.0] - 2015-09-15
+### Added
+- Retention time prediction
+- Ability to filter low-number b/y-ions for faster preliminary scoring (`database.min_ion_index` option)
+- Ability to toggle retention time prediction (`predict_rt`)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1216,7 +1216,6 @@ dependencies = [
  "log",
  "quick-xml",
  "rayon",
- "regex",
  "serde",
  "serde_json",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1176,7 +1176,7 @@ checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
 
 [[package]]
 name = "sage-cli"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1195,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "sage-cloudpath"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "async-compression",
  "aws-config",
@@ -1209,7 +1209,7 @@ dependencies = [
 
 [[package]]
 name = "sage-core"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "async-compression",
  "base64",

--- a/README.md
+++ b/README.md
@@ -135,9 +135,16 @@ Running Sage will produce several output files (located in either the current di
 
 ## Configuration file schema
 
-Notes:
+### Notes
+
 - The majority of parameters are optional - only "database.fasta", "precursor_tol", and "fragment_tol" are required. Sage will try and use reasonable defaults for any parameters not supplied
 - Tolerances are specified on the *experimental* m/z values. To perform a -100 to +500 Da open search (mass window applied to *precursor*), you would use `"da": [-500, 100]`
+
+### Decoys
+
+Using decoy sequences is critical to controlling the false discovery rate in proteomics experiments. Sage can use decoy sequences in the supplied FASTA file, or it can generate internal sequences. Sage reverses tryptic peptides (not proteins), so that the [picked-peptide](https://pubmed.ncbi.nlm.nih.gov/36166314/) approach to FDR can be used.
+
+If `database.generate_decoys` is set to true (or unspecified), then decoy sequences in the FASTA database matching `database.decoy_tag` will be *ignored*, and Sage will internally generate decoys. It is __critical__ that you ensure you use the proper `decoy_tag` if you are using a FASTA database containing decoys and have internal decoy generation turned on - otherwise Sage will treat the supplied decoys as hits!
 
 ```jsonc
 // Note that json does not allow comments, they are here just as explanation
@@ -161,8 +168,9 @@ Notes:
     "variable_mods": {      // Optional[Dict[char, float]] {default={}}, variable modifications
       "M": 15.9949          // Variable mods are applied *before* static mods
     },
-    "decoy_prefix": "rev_", // Optional[str] {default="rev_"}: Prefix appended to decoy proteins
-    "fasta": "dual.fasta"   // str: mandatory path to fasta file
+    "decoy_tag": "rev_",    // Optional[str] {default="rev_"}: See notes above
+    "generate_decoys": false  // Optional[bool] {default="true"}: Ignore decoys in FASTA database matching `decoy_tag`
+    "fasta": "dual.fasta"   // str: mandatory path to FASTA file
   },
   "quant": {                // Optional - specify only if TMT or LFQ
     "tmt": "Tmt16",         // Optional[str] {default=null}, one of "Tmt6", "Tmt10", "Tmt11", "Tmt16", or "Tmt18"

--- a/README.md
+++ b/README.md
@@ -130,8 +130,8 @@ sage config.json s3://my-bucket/YYYY-MM-DD_expt_A_fraction_1.mzML.gz
 
 Running Sage will produce several output files (located in either the current directory, or `output_directory` if that option is specified):
 - Record of search parameters (`results.json`) will be created that details input/output paths and all search parameters used for the search
-- MS2 search results will be stored as a Percolator-compatible (`search.pin`) file - this is a tab-separated file, which can be opened in Excel/Pandas/etc
-- MS3 search results will be stored as a CSV (`quant.csv`) if `quant.tmt` option is used in the parameter file
+- MS2 search results will be stored as a tab-separated file (`results.sage.tsv`) file - this is a tab-separated file, which can be opened in Excel/Pandas/etc
+- MS3 search results will be stored as a tab-separated file (`quant.tsv`) if `quant.tmt` option is used in the parameter file
 
 ## Configuration file schema
 
@@ -145,6 +145,8 @@ Running Sage will produce several output files (located in either the current di
 Using decoy sequences is critical to controlling the false discovery rate in proteomics experiments. Sage can use decoy sequences in the supplied FASTA file, or it can generate internal sequences. Sage reverses tryptic peptides (not proteins), so that the [picked-peptide](https://pubmed.ncbi.nlm.nih.gov/36166314/) approach to FDR can be used.
 
 If `database.generate_decoys` is set to true (or unspecified), then decoy sequences in the FASTA database matching `database.decoy_tag` will be *ignored*, and Sage will internally generate decoys. It is __critical__ that you ensure you use the proper `decoy_tag` if you are using a FASTA database containing decoys and have internal decoy generation turned on - otherwise Sage will treat the supplied decoys as hits!
+
+Internally generated decoys will have protein accessions matching "{decoy_tag}{accession}", e.g. if `decoy_tag` is "rev_" then a protein accession like "rev_sp|P01234|HUMAN" will be listed in the output file.
 
 ```jsonc
 // Note that json does not allow comments, they are here just as explanation

--- a/crates/sage-cli/Cargo.toml
+++ b/crates/sage-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sage-cli"
-version = "0.5.1"
+version = "0.6.0"
 authors = ["Michael Lazear <michaellazear92@gmail.com"]
 edition = "2021"
 rust-version = "1.62"

--- a/crates/sage-cli/src/main.rs
+++ b/crates/sage-cli/src/main.rs
@@ -190,7 +190,7 @@ impl Runner {
         record.push_field(feature.proteins.as_str().as_bytes());
         record.push_field(itoa::Buffer::new().format(feature.num_proteins).as_bytes());
         record.push_field(self.parameters.mzml_paths[feature.file_id].as_bytes());
-        record.push_field(itoa::Buffer::new().format(feature.scannr).as_bytes());
+        record.push_field(feature.spec_id.as_bytes());
         record.push_field(itoa::Buffer::new().format(feature.label).as_bytes());
         record.push_field(ryu::Buffer::new().format(feature.expmass).as_bytes());
         record.push_field(ryu::Buffer::new().format(feature.calcmass).as_bytes());
@@ -326,8 +326,8 @@ impl Runner {
             .into_par_iter()
             .map(|q| {
                 let mut record = csv::ByteRecord::new();
-                record.push_field(itoa::Buffer::new().format(q.file_id).as_bytes());
-                record.push_field(itoa::Buffer::new().format(q.scannr).as_bytes());
+                record.push_field(self.parameters.mzml_paths[q.file_id].as_bytes());
+                record.push_field(q.spec_id.as_bytes());
                 record.push_field(ryu::Buffer::new().format(q.ion_injection_time).as_bytes());
                 for peak in &q.peaks {
                     record.push_field(ryu::Buffer::new().format(*peak).as_bytes());

--- a/crates/sage-cli/src/main.rs
+++ b/crates/sage-cli/src/main.rs
@@ -191,6 +191,7 @@ impl Runner {
         record.push_field(itoa::Buffer::new().format(feature.num_proteins).as_bytes());
         record.push_field(self.parameters.mzml_paths[feature.file_id].as_bytes());
         record.push_field(feature.spec_id.as_bytes());
+        record.push_field(itoa::Buffer::new().format(feature.rank).as_bytes());
         record.push_field(itoa::Buffer::new().format(feature.label).as_bytes());
         record.push_field(ryu::Buffer::new().format(feature.expmass).as_bytes());
         record.push_field(ryu::Buffer::new().format(feature.calcmass).as_bytes());
@@ -255,8 +256,9 @@ impl Runner {
             "peptide",
             "proteins",
             "num_proteins",
-            "file",
+            "filename",
             "scannr",
+            "rank",
             "label",
             "expmass",
             "calcmass",
@@ -286,13 +288,8 @@ impl Runner {
             "ms1_intensity",
         ]);
 
-        // for feat in features {
-        // wtr.serialize(feat)?;
-        // }
-
         wtr.write_byte_record(&headers)?;
         for record in features
-            // .par_iter()
             .into_par_iter()
             .map(|feat| self.serialize_feature(&feat))
             .collect::<Vec<_>>()

--- a/crates/sage-cli/src/main.rs
+++ b/crates/sage-cli/src/main.rs
@@ -280,7 +280,7 @@ impl Runner {
             "matched_intensity_pct",
             "scored_candidates",
             "poisson",
-            "discriminant_score",
+            "sage_discriminant_score",
             "posterior_error",
             "spectrum_fdr",
             "peptide_fdr",

--- a/crates/sage-cloudpath/Cargo.toml
+++ b/crates/sage-cloudpath/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sage-cloudpath"
-version = "0.5.1"
+version = "0.6.0"
 authors = ["Michael Lazear <michaellazear92@gmail.com"]
 edition = "2021"
 rust-version = "1.62"

--- a/crates/sage-cloudpath/src/lib.rs
+++ b/crates/sage-cloudpath/src/lib.rs
@@ -4,7 +4,7 @@ use http::Uri;
 use sage_core::mzml::{MzMLError, MzMLReader, Spectrum};
 use std::path::PathBuf;
 use std::str::FromStr;
-use tokio::io::{AsyncBufRead, AsyncRead, AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncBufRead, AsyncRead, AsyncWriteExt, BufReader};
 
 static S3_CLIENT: once_cell::sync::OnceCell<aws_sdk_s3::Client> = once_cell::sync::OnceCell::new();
 

--- a/crates/sage-cloudpath/src/lib.rs
+++ b/crates/sage-cloudpath/src/lib.rs
@@ -82,6 +82,13 @@ impl CloudPath {
         }
     }
 
+    pub fn filename(&self) -> Option<&str> {
+        match self {
+            CloudPath::S3 { key, .. } => key.split('/').last(),
+            CloudPath::Local(path) => path.file_name().and_then(|s| s.to_str()),
+        }
+    }
+
     /// Does the path end in "gz" or "gzip"?
     fn gzip_heuristic(&self) -> bool {
         match &self {

--- a/crates/sage/Cargo.toml
+++ b/crates/sage/Cargo.toml
@@ -14,7 +14,6 @@ license = "MIT"
 async-compression = { version = "0.3", features = ["tokio", "gzip", "zlib"] }
 base64 = "0.13"
 log = "0.4.0"
-regex = "1.6"
 tokio = { version = "1.0", features = ["io-util"] }
 rayon = "1.5"
 serde = { version="1.0", features = ["derive"] }

--- a/crates/sage/Cargo.toml
+++ b/crates/sage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sage-core"
-version = "0.5.1"
+version = "0.6.0"
 authors = ["Michael Lazear <michaellazear92@gmail.com"]
 edition = "2021"
 rust-version = "1.62"

--- a/crates/sage/src/lfq.rs
+++ b/crates/sage/src/lfq.rs
@@ -31,8 +31,6 @@ struct LfqEntry {
     mz_tol_lo: f32,
     mz_tol_hi: f32,
 
-    // index of Feature vector scan
-    feat_idx: usize,
     peptide: PeptideIx,
 }
 
@@ -64,8 +62,7 @@ impl LfqIndex {
 
         let mut entries = features
             .par_iter()
-            .enumerate()
-            .flat_map(|(feat_idx, feat)| {
+            .flat_map(|feat| {
                 (min_charge..=max_charge)
                     .par_bridge()
                     .flat_map_iter(move |charge| {
@@ -78,7 +75,6 @@ impl LfqIndex {
 
                             LfqEntry {
                                 rt: feat.rt,
-                                feat_idx,
                                 peptide: feat.peptide_idx,
                                 isotope: isotopomer,
                                 charge,

--- a/crates/sage/src/mass.rs
+++ b/crates/sage/src/mass.rs
@@ -93,7 +93,13 @@ impl std::fmt::Display for Residue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Residue::Just(c) => f.write_char(*c),
-            Residue::Mod(c, m) => write!(f, "{}({})", c, m),
+            Residue::Mod(c, m) => {
+                if m.is_sign_positive() {
+                    write!(f, "{}[+{}]", c, m)
+                } else {
+                    write!(f, "{}[{}]", c, m)
+                }
+            }
         }
     }
 }

--- a/crates/sage/src/mzml.rs
+++ b/crates/sage/src/mzml.rs
@@ -8,7 +8,8 @@ use tokio::io::{AsyncBufRead, AsyncRead, AsyncReadExt, AsyncWriteExt, BufReader}
 #[derive(Default, Debug, Clone)]
 pub struct Spectrum {
     pub ms_level: u8,
-    pub scan_id: usize,
+    pub id: String,
+    // pub scan_id: Option<usize>,
     pub precursors: Vec<Precursor>,
     /// Profile or Centroided data
     pub representation: Representation,
@@ -149,27 +150,30 @@ impl MzMLReader {
                         b"spectrum" => {
                             let id = extract!(ev, b"id");
                             let id = std::str::from_utf8(&id)?;
-                            match scan_id_regex.captures(id).and_then(|c| c.get(1)) {
-                                Some(m) => {
-                                    spectrum.scan_id = m.as_str().parse()?;
-                                }
-                                None => {
-                                    // fallback, try and extract from index
-                                    let index = extract!(ev, b"index");
-                                    let index = std::str::from_utf8(&index)?.parse::<usize>()?;
-                                    spectrum.scan_id = index + 1;
-                                }
-                            }
+                            spectrum.id = id.to_string();
+                            // spectrum.scan_id = scan_id_regex.captures(id)
+                            // match scan_id_regex.captures(id).and_then(|c| c.get(1)) {
+                            //     Some(m) => {
+                            //         spectrum.scan_id = m.as_str().parse()?;
+                            //     }
+                            //     None => {
+                            //         // fallback, try and extract from index
+                            //         let index = extract!(ev, b"index");
+                            //         let index = std::str::from_utf8(&index)?.parse::<usize>()?;
+                            //         spectrum.scan_id = index + 1;
+                            //     }
+                            // }
                         }
                         b"precursor" => {
                             // Not all precursor fields have a spectrumRef
                             if let Some(scan) = ev.try_get_attribute(b"spectrumRef")? {
                                 let scan = std::str::from_utf8(&scan.value)?;
-                                precursor.scan = scan_id_regex
-                                    .captures(scan)
-                                    .and_then(|c| c.get(1))
-                                    .map(|m| m.as_str().parse::<usize>())
-                                    .transpose()?;
+                                precursor.spectrum_ref = Some(scan.to_string())
+                                // precursor.scan = scan_id_regex
+                                //     .captures(scan)
+                                //     .and_then(|c| c.get(1))
+                                //     .map(|m| m.as_str().parse::<usize>())
+                                //     .transpose()?;
                             }
                         }
                         _ => {}

--- a/crates/sage/src/mzml.rs
+++ b/crates/sage/src/mzml.rs
@@ -3,7 +3,7 @@ use crate::spectrum::Precursor;
 use async_compression::tokio::bufread::ZlibDecoder;
 use quick_xml::events::Event;
 use quick_xml::Reader;
-use tokio::io::{AsyncBufRead, AsyncRead, AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncBufRead, AsyncReadExt};
 
 #[derive(Default, Debug, Clone)]
 pub struct Spectrum {
@@ -149,29 +149,12 @@ impl MzMLReader {
                             let id = extract!(ev, b"id");
                             let id = std::str::from_utf8(&id)?;
                             spectrum.id = id.to_string();
-                            // spectrum.scan_id = scan_id_regex.captures(id)
-                            // match scan_id_regex.captures(id).and_then(|c| c.get(1)) {
-                            //     Some(m) => {
-                            //         spectrum.scan_id = m.as_str().parse()?;
-                            //     }
-                            //     None => {
-                            //         // fallback, try and extract from index
-                            //         let index = extract!(ev, b"index");
-                            //         let index = std::str::from_utf8(&index)?.parse::<usize>()?;
-                            //         spectrum.scan_id = index + 1;
-                            //     }
-                            // }
                         }
                         b"precursor" => {
                             // Not all precursor fields have a spectrumRef
                             if let Some(scan) = ev.try_get_attribute(b"spectrumRef")? {
                                 let scan = std::str::from_utf8(&scan.value)?;
                                 precursor.spectrum_ref = Some(scan.to_string())
-                                // precursor.scan = scan_id_regex
-                                //     .captures(scan)
-                                //     .and_then(|c| c.get(1))
-                                //     .map(|m| m.as_str().parse::<usize>())
-                                //     .transpose()?;
                             }
                         }
                         _ => {}

--- a/crates/sage/src/mzml.rs
+++ b/crates/sage/src/mzml.rs
@@ -123,8 +123,6 @@ impl MzMLReader {
         let mut iso_window_hi: Option<f32> = None;
         let mut spectra = Vec::new();
 
-        let scan_id_regex = regex::Regex::new(r#"scan=(\d+)"#).expect("this is a valid regex");
-
         macro_rules! extract {
             ($ev:expr, $key:expr) => {
                 $ev.try_get_attribute($key)?

--- a/crates/sage/src/peptide.rs
+++ b/crates/sage/src/peptide.rs
@@ -166,7 +166,11 @@ impl TryFrom<&Digest> for Peptide {
 impl std::fmt::Display for Peptide {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if let Some(m) = self.nterm {
-            write!(f, "[{}]", m)?;
+            if m.is_sign_positive() {
+                write!(f, "[+{}]-", m)?;
+            } else {
+                write!(f, "[{}]-", m)?;
+            }
         }
         f.write_str(
             &self
@@ -194,14 +198,14 @@ mod test {
         .unwrap();
 
         let expected = vec![
-            "GC(57)M(16)GCMG",
-            "GCM(16)GC(57)MG",
-            "GCM(16)GCMG",
-            "GC(57)MGCM(16)G",
-            "GCMGC(57)M(16)G",
-            "GCMGCM(16)G",
-            "GC(57)MGCMG",
-            "GCMGC(57)MG",
+            "GC[+57]M[+16]GCMG",
+            "GCM[+16]GC[+57]MG",
+            "GCM[+16]GCMG",
+            "GC[+57]MGCM[+16]G",
+            "GCMGC[+57]M[+16]G",
+            "GCMGCM[+16]G",
+            "GC[+57]MGCMG",
+            "GCMGC[+57]MG",
             "GCMGCMG",
         ];
 
@@ -232,11 +236,11 @@ mod test {
         .unwrap();
 
         let expected = vec![
-            "[42]GCM(16)GCMG",
-            "[42]GCMGCM(16)G",
-            "[42]GCMGCMG",
-            "GCM(16)GCMG",
-            "GCMGCM(16)G",
+            "[+42]-GCM[+16]GCMG",
+            "[+42]-GCMGCM[+16]G",
+            "[+42]-GCMGCMG",
+            "GCM[+16]GCMG",
+            "GCMGCM[+16]G",
             "GCMGCMG",
         ];
 
@@ -292,7 +296,11 @@ mod test {
         })
         .unwrap();
 
-        let expected = vec!["AAC(30)AAC(57)AA", "AAC(57)AAC(30)AA", "AAC(57)AAC(57)AA"];
+        let expected = vec![
+            "AAC[+30]AAC[+57]AA",
+            "AAC[+57]AAC[+30]AA",
+            "AAC[+57]AAC[+57]AA",
+        ];
 
         let mut static_mods = HashMap::new();
         static_mods.insert('C', 57.0);

--- a/crates/sage/src/scoring.rs
+++ b/crates/sage/src/scoring.rs
@@ -243,6 +243,7 @@ impl<'db> Scorer<'db> {
             .iter()
             .take(n_calculate)
             .map(|pre| self.score_candidate(query, charge, pre.peptide))
+            .filter(|s| (s.matched_b + s.matched_y) >= 2)
             .collect::<Vec<_>>();
 
         score_vector.sort_unstable_by(|a, b| b.hyperscore.total_cmp(&a.hyperscore));

--- a/crates/sage/src/spectrum.rs
+++ b/crates/sage/src/spectrum.rs
@@ -31,12 +31,13 @@ pub struct SpectrumProcessor {
     pub file_id: usize,
 }
 
-#[derive(Default, Debug, Copy, Clone, Serialize)]
+#[derive(Default, Debug, Clone, Serialize)]
 pub struct Precursor {
     pub mz: f32,
     pub intensity: Option<f32>,
     pub charge: Option<u8>,
-    pub scan: Option<usize>,
+    // pub scan: Option<usize>,
+    pub spectrum_ref: Option<String>,
     pub isolation_window: Option<Tolerance>,
 }
 
@@ -45,7 +46,8 @@ pub struct ProcessedSpectrum {
     /// MSn level
     pub level: u8,
     /// Scan ID
-    pub scan: usize,
+    pub id: String,
+    // pub scan: usize,
     /// File ID
     pub file_id: usize,
     /// Retention time
@@ -97,22 +99,22 @@ pub fn select_closest_peak(peaks: &[Peak], mz: f32, tolerance: Tolerance) -> Opt
     best_peak
 }
 
-pub fn find_spectrum_by_id(
-    spectra: &[ProcessedSpectrum],
-    scan_id: usize,
-) -> Option<&ProcessedSpectrum> {
-    // First try indexing by scan
-    if let Some(first) = spectra.get(scan_id.saturating_sub(1)) {
-        if first.scan == scan_id {
-            return Some(first);
-        }
-    }
-    // Fall back to binary search
-    let idx = spectra
-        .binary_search_by(|spec| spec.scan.cmp(&scan_id))
-        .ok()?;
-    spectra.get(idx)
-}
+// pub fn find_spectrum_by_id(
+//     spectra: &[ProcessedSpectrum],
+//     scan_id: usize,
+// ) -> Option<&ProcessedSpectrum> {
+//     // First try indexing by scan
+//     if let Some(first) = spectra.get(scan_id.saturating_sub(1)) {
+//         if first.scan == scan_id {
+//             return Some(first);
+//         }
+//     }
+//     // Fall back to binary search
+//     let idx = spectra
+//         .binary_search_by(|spec| spec.scan.cmp(&scan_id))
+//         .ok()?;
+//     spectra.get(idx)
+// }
 
 /// Deisotope a set of peaks by attempting to find C13 peaks under a given `ppm` tolerance
 pub fn deisotope(mz: &[f32], int: &[f32], max_charge: u8, ppm: f32) -> Vec<Deisotoped> {
@@ -209,7 +211,7 @@ impl SpectrumProcessor {
             // Panic, because there's really nothing we can do with profile data
             panic!(
                 "Scan {} contains profile data! Please convert to centroid",
-                spectrum.scan_id
+                spectrum.id
             );
         }
 
@@ -281,7 +283,8 @@ impl SpectrumProcessor {
 
         ProcessedSpectrum {
             level: spectrum.ms_level,
-            scan: spectrum.scan_id,
+            id: spectrum.id,
+            // scan: spectrum.scan_id,
             file_id: self.file_id,
             scan_start_time: spectrum.scan_start_time,
             ion_injection_time: spectrum.ion_injection_time,

--- a/crates/sage/src/tmt.rs
+++ b/crates/sage/src/tmt.rs
@@ -1,5 +1,6 @@
 //! TMT quantification
 #![allow(clippy::excessive_precision)]
+#![allow(unused_imports)]
 use crate::database::binary_search_slice;
 use crate::ion_series::{IonSeries, Kind};
 use crate::mass::{Tolerance, H2O, NH3, PROTON};


### PR DESCRIPTION
This is a more correct thing to do - mzML files are not guaranteed to have a "scan=(\d)" part in the spectrum id field

**Breaking changes:**

- Add a `rank` column to output file
- Rename `discriminant_score` to `sage_discriminant_score`
- Use base proforma notation for peptide mods, i.e. "[+304.2071]-PEPTIDEM[+15.9949]AAC[+57.0214]H"
- Replace scannr with nativeID, i.e. "controllerType=0 controllerNumber=1 scan=30069"