### PR TITLE
Change docker image from Alpine to Debian

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-          target: x86_64-unknown-linux-musl
+          target: x86_64-unknown-linux-gnu
           override: true
 
       - name: Build Sage
@@ -27,7 +27,7 @@ jobs:
         with:
           use-cross: true
           command: build
-          args: --release --target x86_64-unknown-linux-musl
+          args: --release --target x86_64-unknown-linux-gnu
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,7 @@
-FROM alpine:latest
-
-RUN apk add --no-cache bash
+FROM debian:bullseye-slim
 
 WORKDIR /app
 
-COPY target/x86_64-unknown-linux-musl/release/sage ./sage
+COPY target/x86_64-unknown-linux-gnu/release/sage /app/sage
 
 ENV PATH="/app:$PATH"


### PR DESCRIPTION
I was having trouble with interoperability using a Alpine-based image (mostly trying to use the AWS CLI, even through the host system). I think transitioning to a Debian-based image that uses glibc instead of musl would resolve some headaches 🙃. 