### PR TITLE
Add procps to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM debian:bullseye-slim
 
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends procps \
+    && rm -rf /var/lib/apt /var/lib/dpkg /var/lib/cache /var/lib/log
+
 WORKDIR /app
 
 COPY target/x86_64-unknown-linux-gnu/release/sage /app/sage


### PR DESCRIPTION
Sorry for the PR spam!

I was too quick my last PR and forgot that NextFlow needs the `ps` command for tracing, and the debian slim base images don't have `procps` installed by default. Anyways, this PR installs `procps` so that it should work nicely.

Hopefully this is the last Docker image update for awhile 😅 