### PR TITLE
Global retention time alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ Check out the [blog post introducing Sage](https://lazear.github.io/sage/) for m
 
 ### Sage trains machine learning models for FDR refinement and posterior error probability calculation
 
-- Boosts PSM identifications using prediction of retention times with a [linear regression](https://doi.org/10.1021/ac070262k) model fit to each LC/MS run
+- Retention times are globally aligned across runs
+- Boosts PSM identifications using prediction of retention times with a [linear regression](https://doi.org/10.1021/ac070262k) model
 - Hand-rolled, 100% pure Rust implementations of Linear Discriminant Analysis and KDE-mixture models for refinement of false discovery rates
 - Models demonstrate 1:1 results with scikit-learn, but have increased performance
 - No need for a second post-search pipeline step

--- a/crates/sage-cli/src/main.rs
+++ b/crates/sage-cli/src/main.rs
@@ -216,6 +216,7 @@ impl Runner {
                 .as_bytes(),
         );
         record.push_field(ryu::Buffer::new().format(feature.rt).as_bytes());
+        record.push_field(ryu::Buffer::new().format(feature.aligned_rt).as_bytes());
         record.push_field(ryu::Buffer::new().format(feature.predicted_rt).as_bytes());
         record.push_field(ryu::Buffer::new().format(feature.delta_rt).as_bytes());
         record.push_field(itoa::Buffer::new().format(feature.matched_peaks).as_bytes());
@@ -280,6 +281,7 @@ impl Runner {
             "hyperscore",
             "delta_hyperscore",
             "rt",
+            "aligned_rt",
             "predicted_rt",
             "delta_rt",
             "matched_peaks",
@@ -537,10 +539,10 @@ impl Runner {
         };
 
         if self.parameters.predict_rt {
-            // let _ = sage_core::ml::retention_alignment::global_alignment(
-            //     &mut outputs.features,
-            //     self.parameters.mzml_paths.len(),
-            // );
+            sage_core::ml::retention_alignment::global_alignment(
+                &mut outputs.features,
+                self.parameters.mzml_paths.len(),
+            );
             let _ = sage_core::ml::retention_model::predict(&self.database, &mut outputs.features);
         }
 

--- a/crates/sage-cli/src/main.rs
+++ b/crates/sage-cli/src/main.rs
@@ -365,10 +365,6 @@ impl Runner {
             .flat_map(|spec| scorer.score(spec, self.parameters.report_psms))
             .collect();
 
-        if self.parameters.predict_rt {
-            let _ = sage_core::ml::retention_model::predict(&self.database, &mut features);
-        }
-
         if self.parameters.quant.lfq.unwrap_or(false) {
             sage_core::lfq::quantify(&mut features, &spectra);
         }
@@ -539,6 +535,14 @@ impl Runner {
                 .flat_map(|(file_id, path)| self.process_file(&scorer, path, file_id))
                 .collect::<SageResults>(),
         };
+
+        if self.parameters.predict_rt {
+            // let _ = sage_core::ml::retention_alignment::global_alignment(
+            //     &mut outputs.features,
+            //     self.parameters.mzml_paths.len(),
+            // );
+            let _ = sage_core::ml::retention_model::predict(&self.database, &mut outputs.features);
+        }
 
         let q_spectrum = self.spectrum_fdr(&mut outputs.features);
         let q_peptide = sage_core::fdr::picked_peptide(&self.database, &mut outputs.features);

--- a/crates/sage/src/ml/gauss.rs
+++ b/crates/sage/src/ml/gauss.rs
@@ -48,7 +48,7 @@ impl Gauss {
     fn fill_zero(&mut self) {
         for i in 0..self.left.cols {
             // I'm no mathematician, so hopefully this is a reasonable epsilon :)
-            self.left[(i, i)] += 1.0;
+            self.left[(i, i)] += 1.0E-8;
         }
     }
 

--- a/crates/sage/src/ml/gauss.rs
+++ b/crates/sage/src/ml/gauss.rs
@@ -47,10 +47,8 @@ impl Gauss {
     ///  and it is easy to prove that for reasonable epsilon, this will be inversible"
     fn fill_zero(&mut self) {
         for i in 0..self.left.cols {
-            if self.left[(i, i)] == 0.0 {
-                // I'm no mathematician, so hopefully this is a reasonable epsilon :)
-                self.left[(i, i)] = 1E-8;
-            }
+            // I'm no mathematician, so hopefully this is a reasonable epsilon :)
+            self.left[(i, i)] += 1.0;
         }
     }
 
@@ -62,9 +60,11 @@ impl Gauss {
                 let x = self.left[(i, j)];
                 if i == j {
                     if x != 1.0 && x != 0.0 {
+                        log::warn!("Finding solution to linear system failed: left side of matrix [{},{}] = {}", i, j, x);
                         return false;
                     }
                 } else if x != 0.0 {
+                    log::warn!("Finding solution to linear system failed: left side of matrix [{},{}] = {}", i, j, x);
                     return false;
                 }
             }

--- a/crates/sage/src/ml/linear_discriminant.rs
+++ b/crates/sage/src/ml/linear_discriminant.rs
@@ -145,7 +145,7 @@ pub fn score_psms(scores: &mut [Feature]) -> Option<()> {
                 (perc.peptide_len as f64).ln_1p(),
                 (perc.missed_cleavages as f64),
                 (perc.aligned_rt as f64),
-                (perc.delta_rt as f64).sqrt(),
+                (perc.delta_rt as f64).clamp(0.001, 0.999).sqrt(),
             ];
             x
         })

--- a/crates/sage/src/ml/linear_discriminant.rs
+++ b/crates/sage/src/ml/linear_discriminant.rs
@@ -63,7 +63,6 @@ impl LinearDiscriminantAnalysis {
             let count = decoy.iter().filter(|&label| *label == class).count();
 
             let class_data = (0..features.rows)
-                .into_iter()
                 .zip(decoy)
                 .filter(|&(_, label)| *label == class)
                 .flat_map(|(row, _)| features.row(row))

--- a/crates/sage/src/ml/linear_discriminant.rs
+++ b/crates/sage/src/ml/linear_discriminant.rs
@@ -31,7 +31,7 @@ const FEATURE_NAMES: [&str; FEATURES] = [
     "ln1p(peptide_len)",
     "missed_cleavages",
     "rt",
-    "ln1p(delta_rt)",
+    "sqrt(delta_rt)",
 ];
 
 struct Features<'a>(&'a [f64]);
@@ -144,8 +144,8 @@ pub fn score_psms(scores: &mut [Feature]) -> Option<()> {
                 (perc.longest_y as f64 / perc.peptide_len as f64),
                 (perc.peptide_len as f64).ln_1p(),
                 (perc.missed_cleavages as f64),
-                (perc.rt as f64),
-                (perc.delta_rt as f64).ln_1p(),
+                (perc.aligned_rt as f64),
+                (perc.delta_rt as f64).sqrt(),
             ];
             x
         })

--- a/crates/sage/src/ml/mod.rs
+++ b/crates/sage/src/ml/mod.rs
@@ -5,6 +5,7 @@ pub mod kde;
 pub mod linear_discriminant;
 pub mod matrix;
 pub mod qvalue;
+pub mod retention_alignment;
 pub mod retention_model;
 
 #[allow(dead_code)]

--- a/crates/sage/src/ml/retention_alignment.rs
+++ b/crates/sage/src/ml/retention_alignment.rs
@@ -36,7 +36,7 @@ fn max_rt_by_file(features: &[Feature], n_files: usize) -> Vec<f64> {
         } else {
             feat.rt
         };
-        max_rt[feat.file_id].fetch_max(rt.ceil() as u32, std::sync::atomic::Ordering::Relaxed);
+        max_rt[feat.file_id].fetch_max(rt.ceil() as u32, std::sync::atomic::Ordering::SeqCst);
     });
 
     max_rt

--- a/crates/sage/src/ml/retention_alignment.rs
+++ b/crates/sage/src/ml/retention_alignment.rs
@@ -1,0 +1,131 @@
+use std::collections::HashMap;
+use std::hash::BuildHasherDefault;
+
+use super::matrix::Matrix;
+use crate::database::PeptideIx;
+use crate::scoring::Feature;
+use dashmap::DashMap;
+use fnv::FnvHasher;
+use rayon::prelude::*;
+
+type FnvDashMap<K, V> = DashMap<K, V, BuildHasherDefault<FnvHasher>>;
+
+fn mean_rt_by_file(features: &[Feature]) -> FnvDashMap<PeptideIx, HashMap<usize, f64>> {
+    let rts: FnvDashMap<PeptideIx, HashMap<usize, Vec<f64>>> = DashMap::default();
+    // let max_rt: FnvDashMap<usize, f64> = DashMap::default();
+
+    features.par_iter().for_each(|feat| {
+        // If LFQ is performed, we should use MS1 apex RT, rather than PSM retention times
+        if feat.ms1_apex_rt > 0.0 {
+            rts.entry(feat.peptide_idx)
+                .or_default()
+                .entry(feat.file_id)
+                .or_default()
+                .push(feat.ms1_apex_rt as f64);
+        } else {
+            rts.entry(feat.peptide_idx)
+                .or_default()
+                .entry(feat.file_id)
+                .or_default()
+                .push(feat.rt as f64);
+        }
+
+        // let mut curr_max = max_rt.entry(feat.file_id).or_default();
+        // *curr_max = curr_max.max(feat.rt as f64);
+    });
+
+    // Use the average RT for each file
+    rts.into_par_iter()
+        .map(|(ix, map)| {
+            let map = map
+                .into_iter()
+                .map(|(file_id, rts)| {
+                    // let file_max_rt = max_rt.get(&file_id).map(|e| e.value()).unwrap_or(200.0);
+
+                    (file_id, super::mean(&rts))
+                })
+                .collect();
+            (ix, map)
+        })
+        .collect()
+}
+
+fn rt_matrix(features: &[Feature], n_files: usize) -> Matrix {
+    let mean_rt = mean_rt_by_file(features);
+
+    let mat = mean_rt
+        .par_iter()
+        .filter(|entry| entry.value().len() >= 2)
+        .flat_map(|entry| {
+            let mut v = vec![f64::NAN; n_files];
+            for (file_id, rt) in entry.value() {
+                v[*file_id] = *rt;
+            }
+            v
+        })
+        .collect::<Vec<_>>();
+
+    Matrix::new(mat, mean_rt.len(), n_files)
+}
+
+pub fn global_alignment(features: &mut [Feature], n_files: usize) {
+    if n_files < 2 {
+        return;
+    }
+
+    let rt = rt_matrix(features, n_files);
+
+    let mean_rts: Vec<f64> = (0..rt.rows)
+        .into_par_iter()
+        .map(|row| {
+            // Don't include NaN values
+            let (len, sum) = rt
+                .row(row)
+                .filter(|rt| rt.is_finite())
+                .fold((0, 0.0f64), |(len, sum), x| (len + 1, sum + x));
+            sum / len as f64
+        })
+        .collect();
+
+    // for file_idx in 0..n_files {
+    let reg = (0..n_files)
+        .into_par_iter()
+        .map(|file_idx| {
+            // calculate dot product across all ID'ed peptides
+            let (len, dot, sum_x, sum_y) = rt
+                .col(file_idx)
+                .zip(mean_rts.iter())
+                .filter(|(x, _)| x.is_finite())
+                .fold(
+                    (0, 0.0f64, 0.0f64, 0.0f64),
+                    |(len, dot, sum_x, sum_y), (x, y)| (len + 1, dot + x * y, sum_x + x, sum_y + y),
+                );
+
+            let x_mean = sum_x / len as f64;
+            let y_mean = sum_y / len as f64;
+            let ssxy = dot - len as f64 * x_mean * y_mean;
+
+            let sx2 = rt
+                .col(file_idx)
+                .filter(|rt| rt.is_finite())
+                .fold(0.0f64, |sum, x| sum + (x - x_mean).powi(2));
+
+            let slope = ssxy / sx2;
+            let intercept = y_mean - slope * x_mean;
+
+            log::info!(
+                "running linear regression {file}: y = {m}x+{b}",
+                file = file_idx,
+                m = slope,
+                b = intercept
+            );
+
+            (slope, intercept)
+        })
+        .collect::<Vec<(f64, f64)>>();
+
+    features.par_iter_mut().for_each(|feature| {
+        let (slope, intercept) = reg[feature.file_id];
+        feature.rt = feature.rt * (slope as f32) + (intercept as f32);
+    });
+}

--- a/crates/sage/src/scoring.rs
+++ b/crates/sage/src/scoring.rs
@@ -374,7 +374,7 @@ impl<'db> Scorer<'db> {
                 peptide_q: 1.0,
                 predicted_rt: 0.0,
                 aligned_rt: query.scan_start_time,
-                delta_rt: 1.0,
+                delta_rt: 0.999,
                 ms2_intensity: better.summed_b + better.summed_y,
                 ms1_intensity: 0.0,
                 ms1_apex: 0.0,

--- a/crates/sage/src/scoring.rs
+++ b/crates/sage/src/scoring.rs
@@ -76,6 +76,8 @@ pub struct Feature {
     pub charge: u8,
     /// Retention time
     pub rt: f32,
+    /// Globally aligned retention time
+    pub aligned_rt: f32,
     /// Predicted RT, if enabled
     pub predicted_rt: f32,
     /// Difference between predicted & observed RT
@@ -371,6 +373,7 @@ impl<'db> Scorer<'db> {
                 protein_q: 1.0,
                 peptide_q: 1.0,
                 predicted_rt: 0.0,
+                aligned_rt: query.scan_start_time,
                 delta_rt: 1.0,
                 ms2_intensity: better.summed_b + better.summed_y,
                 ms1_intensity: 0.0,


### PR DESCRIPTION
This PR introduces improvements to retention time prediction, and increase stability of the linear equations solver

**RT**
Retention times are now globally aligned across files:

- Normalize RTs within a file to unit scale (0.0 - 1.0)
- Align each file following https://pubmed.ncbi.nlm.nih.gov/31260443/

RT prediction is then performed on all files at once (on aligned RTs), rather than one file at a time - previously, there were many instances where some files in a search could not have RTs predicted, decreasing the effectiveness of delta_rt as a feature for LDA.

**Sequence Deduplication**
Peptide sequences within a protein are now deduplicated - previously, repeated peptides would be called multiple times for the same protein (e.g. `num_proteins` > 1 even if the peptide was unique)

**Gaussian solver**
- Add small eps to diagonals of covariance matrix (need to look more into shrinking to determine the best route)