### PR TITLE
slightly better error messages for missing arguments and files

### DIFF
--- a/crates/sage-cli/src/input.rs
+++ b/crates/sage-cli/src/input.rs
@@ -160,12 +160,15 @@ impl Input {
 
         // Handle JSON configuration overrides
         if let Some(output_directory) = matches.get_one::<String>("output_directory") {
+            log::trace!("overriding `output_directory` parameter.");
             input.output_directory = Some(output_directory.into());
         }
         if let Some(fasta) = matches.get_one::<String>("fasta") {
+            log::trace!("overriding `database.fasta` parameter.");
             input.database.fasta = Some(fasta.into());
         }
         if let Some(mzml_paths) = matches.get_many::<String>("mzml_paths") {
+            log::trace!("overriding `mzml_paths` parameter.");
             input.mzml_paths = Some(mzml_paths.into_iter().map(|p| p.into()).collect());
         }
 

--- a/crates/sage-cli/src/input.rs
+++ b/crates/sage-cli/src/input.rs
@@ -177,10 +177,7 @@ impl Input {
         }
 
         // avoid to later panic if these parameters are not set (but doesn't check if files exist)
-        ensure!(
-            input.output_directory.is_some(),
-            "`output_directory` must be set. For more information try '--help'"
-        );
+
         ensure!(
             input.database.fasta.is_some(),
             "`database.fasta` must be set. For more information try '--help'"

--- a/crates/sage-cli/src/input.rs
+++ b/crates/sage-cli/src/input.rs
@@ -1,4 +1,4 @@
-use anyhow::Context;
+use anyhow::{ensure, Context};
 use clap::ArgMatches;
 use sage_cloudpath::CloudPath;
 use sage_core::{
@@ -175,6 +175,20 @@ impl Input {
         if let Some(write_pin) = matches.get_one::<bool>("write-pin").copied() {
             input.write_pin = Some(write_pin);
         }
+
+        // avoid to later panic if these parameters are not set (but doesn't check if files exist)
+        ensure!(
+            input.output_directory.is_some(),
+            "`output_directory` must be set. For more information try '--help'"
+        );
+        ensure!(
+            input.database.fasta.is_some(),
+            "`database.fasta` must be set. For more information try '--help'"
+        );
+        ensure!(
+            input.mzml_paths.is_some(),
+            "`mzml_paths` must be set. For more information try '--help'"
+        );
 
         Ok(input)
     }

--- a/crates/sage-cli/src/input.rs
+++ b/crates/sage-cli/src/input.rs
@@ -160,15 +160,12 @@ impl Input {
 
         // Handle JSON configuration overrides
         if let Some(output_directory) = matches.get_one::<String>("output_directory") {
-            log::trace!("overriding `output_directory` parameter.");
             input.output_directory = Some(output_directory.into());
         }
         if let Some(fasta) = matches.get_one::<String>("fasta") {
-            log::trace!("overriding `database.fasta` parameter.");
             input.database.fasta = Some(fasta.into());
         }
         if let Some(mzml_paths) = matches.get_many::<String>("mzml_paths") {
-            log::trace!("overriding `mzml_paths` parameter.");
             input.mzml_paths = Some(mzml_paths.into_iter().map(|p| p.into()).collect());
         }
 

--- a/crates/sage-cli/src/input.rs
+++ b/crates/sage-cli/src/input.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use clap::ArgMatches;
 use sage_cloudpath::CloudPath;
 use sage_core::{
@@ -154,7 +155,8 @@ impl Input {
         let path = matches
             .get_one::<String>("parameters")
             .expect("required parameters");
-        let mut input = Input::load(path)?;
+        let mut input = Input::load(path)
+            .with_context(|| format!("Failed to read parameters from `{path}`"))?;
 
         // Handle JSON configuration overrides
         if let Some(output_directory) = matches.get_one::<String>("output_directory") {

--- a/crates/sage-cli/src/main.rs
+++ b/crates/sage-cli/src/main.rs
@@ -335,12 +335,14 @@ fn main() -> anyhow::Result<()> {
         .arg(
             Arg::new("parameters")
                 .required(true)
+                .value_parser(clap::builder::NonEmptyStringValueParser::new())
                 .help("Path to configuration parameters (JSON file)")
                 .value_hint(ValueHint::FilePath),
         )
         .arg(
             Arg::new("mzml_paths")
                 .num_args(1..)
+                .value_parser(clap::builder::NonEmptyStringValueParser::new())
                 .help(
                     "Paths to mzML files to process. Overrides mzML files listed in the \
                      configuration file.",
@@ -351,6 +353,7 @@ fn main() -> anyhow::Result<()> {
             Arg::new("fasta")
                 .short('f')
                 .long("fasta")
+                .value_parser(clap::builder::NonEmptyStringValueParser::new())
                 .help(
                     "Path to FASTA database. Overrides the FASTA file \
                      specified in the configuration file.",
@@ -361,6 +364,7 @@ fn main() -> anyhow::Result<()> {
             Arg::new("output_directory")
                 .short('o')
                 .long("output_directory")
+                .value_parser(clap::builder::NonEmptyStringValueParser::new())
                 .help(
                     "Path where search and quant results will be written. \
                      Overrides the directory specified in the configuration file.",
@@ -370,7 +374,7 @@ fn main() -> anyhow::Result<()> {
         .arg(
             Arg::new("batch-size")
                 .long("batch-size")
-                .value_parser(value_parser!(usize))
+                .value_parser(value_parser!(u16).range(1..))
                 .help("Number of files to load and search in parallel (default = # of CPUs/2)")
                 .value_hint(ValueHint::Other),
         )

--- a/crates/sage-cli/src/main.rs
+++ b/crates/sage-cli/src/main.rs
@@ -329,16 +329,28 @@ fn main() -> anyhow::Result<()> {
         .arg(
             Arg::new("parameters")
                 .required(true)
-                .help("Path to configuration parameters (JSON file)"),
+                .help("Path to configuration parameters (JSON file)")
+                .value_hint(ValueHint::FilePath),
         )
-        .arg(Arg::new("mzml_paths").num_args(1..).help(
+        .arg(
+            Arg::new("mzml_paths")
+                .num_args(1..)
+                .help(
             "Paths to mzML files to process. Overrides mzML files listed in the \
                      configuration file.",
-        ))
-        .arg(Arg::new("fasta").short('f').long("fasta").help(
+                )
+                .value_hint(ValueHint::FilePath),
+        )
+        .arg(
+            Arg::new("fasta")
+                .short('f')
+                .long("fasta")
+                .help(
             "Path to FASTA database. Overrides the FASTA file \
                      specified in the configuration file.",
-        ))
+                )
+                .value_hint(ValueHint::FilePath),
+        )
         .arg(
             Arg::new("output_directory")
                 .short('o')
@@ -346,13 +358,15 @@ fn main() -> anyhow::Result<()> {
                 .help(
                     "Path where search and quant results will be written. \
                      Overrides the directory specified in the configuration file.",
-                ),
+                )
+                .value_hint(ValueHint::DirPath),
         )
         .arg(
             Arg::new("batch-size")
                 .long("batch-size")
                 .value_parser(value_parser!(usize))
-                .help("Number of files to load and search in parallel (default = # of CPUs/2)"),
+                .help("Number of files to load and search in parallel (default = # of CPUs/2)")
+                .value_hint(ValueHint::Other),
         )
         .arg(
             Arg::new("write-pin")

--- a/crates/sage-cloudpath/src/lib.rs
+++ b/crates/sage-cloudpath/src/lib.rs
@@ -1,6 +1,5 @@
 use async_compression::tokio::bufread::GzipDecoder;
 use async_compression::tokio::write::GzipEncoder;
-use aws_sdk_s3::types::DisplayErrorContext;
 use http::Uri;
 use std::path::PathBuf;
 use std::str::FromStr;


### PR DESCRIPTION
- make sage fail earlier than later when parameters are not set in the JSON file and are not command line arguments (it made the program panic once the computation started)
- use anyhow's context for errors when reading files, now the problematic file is displayed

```
Error: Failed to read parameters from `missing_file.json`

Caused by:
    IO error: No such file or directory (os error 2)
```