### PR TITLE
Overhaul modifications: multiple variable mods, modifications of specific AA at termini

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Better error reporting thanks to @Elendol
+- Added support for multiple variable mods for the same amino acid
+- Added support for N/C-terminal modifications specific to an individual amino acid
+
+New syntax:
+```json
+"variable_mods": {
+    "M": [15.9949],
+    "^Q": -17.026549,
+    "^E": -18.010565,
+    "[": 42.010565
+}
+```
+
+Either a single floating point number (-18.0) or a list of floating point numbers ([-18.0, -15.2]) can be supplied as modifications. Support for single values will eventually be phased out to simplify the parser.
+
 ### Changed
 - Changed "_fdr" columns to "_q" (e.g. "spectrum_q") in "results.sage.tsv" file
+- Changed internal data representation of `Peptide` struct to allow for sharing of sequences (using `Arc`) among modified peptides
+- Fragment index creation should now be faster
 
 ## [0.12.0]
 ### Added

--- a/crates/sage-cli/src/input.rs
+++ b/crates/sage-cli/src/input.rs
@@ -180,7 +180,12 @@ impl Input {
             "`database.fasta` must be set. For more information try '--help'"
         );
         ensure!(
-            input.mzml_paths.as_ref().map(|p| p.len()).unwrap_or_default() > 0,
+            input
+                .mzml_paths
+                .as_ref()
+                .map(|p| p.len())
+                .unwrap_or_default()
+                > 0,
             "`mzml_paths` must be set. For more information try '--help'"
         );
 

--- a/crates/sage-cli/src/main.rs
+++ b/crates/sage-cli/src/main.rs
@@ -5,7 +5,7 @@ use log::info;
 use rayon::prelude::*;
 use sage_cloudpath::CloudPath;
 use sage_core::database::IndexedDatabase;
-use sage_core::mass::{Mass, Tolerance, VALID_AA};
+use sage_core::mass::Tolerance;
 use sage_core::scoring::{Feature, Scorer};
 use sage_core::spectrum::{ProcessedSpectrum, SpectrumProcessor};
 use sage_core::tmt::TmtQuant;
@@ -399,6 +399,7 @@ fn main() -> anyhow::Result<()> {
     let input = Input::from_arguments(matches)?;
 
     let runner = input.build().and_then(Runner::new)?;
+    runner.database.serialize();
 
     runner.run(parallel)?;
 

--- a/crates/sage-cli/src/main.rs
+++ b/crates/sage-cli/src/main.rs
@@ -69,8 +69,9 @@ impl Runner {
             )
         })?;
         info!(
-            "generated {} fragments in {}ms",
-            database.size(),
+            "generated {} fragments, {} peptides in {}ms",
+            database.fragments.len(),
+            database.peptides.len(),
             (Instant::now() - start).as_millis()
         );
         Ok(Self {
@@ -399,7 +400,6 @@ fn main() -> anyhow::Result<()> {
     let input = Input::from_arguments(matches)?;
 
     let runner = input.build().and_then(Runner::new)?;
-    runner.database.serialize();
 
     runner.run(parallel)?;
 

--- a/crates/sage-cli/src/main.rs
+++ b/crates/sage-cli/src/main.rs
@@ -5,7 +5,7 @@ use log::info;
 use rayon::prelude::*;
 use sage_cloudpath::CloudPath;
 use sage_core::database::IndexedDatabase;
-use sage_core::mass::Tolerance;
+use sage_core::mass::{Mass, Tolerance, VALID_AA};
 use sage_core::scoring::{Feature, Scorer};
 use sage_core::spectrum::{ProcessedSpectrum, SpectrumProcessor};
 use sage_core::tmt::TmtQuant;

--- a/crates/sage-cli/src/output.rs
+++ b/crates/sage-cli/src/output.rs
@@ -10,15 +10,16 @@ impl Runner {
         let mut record = csv::ByteRecord::new();
         let peptide = &self.database[feature.peptide_idx];
         record.push_field(peptide.to_string().as_bytes());
-        record.push_field(peptide.proteins(&self.database.decoy_tag).as_bytes());
+        record.push_field(
+            peptide
+                .proteins(&self.database.decoy_tag, self.database.generate_decoys)
+                .as_bytes(),
+        );
         record.push_field(
             itoa::Buffer::new()
                 .format(peptide.proteins.len())
                 .as_bytes(),
         );
-        // record.push_field(feature.peptide.as_str().as_bytes());
-        // record.push_field(feature.proteins.as_str().as_bytes());
-        // record.push_field(itoa::Buffer::new().format(feature.num_proteins).as_bytes());
         record.push_field(filenames[feature.file_id].as_bytes());
         record.push_field(feature.spec_id.as_bytes());
         record.push_field(itoa::Buffer::new().format(feature.rank).as_bytes());
@@ -123,7 +124,6 @@ impl Runner {
             "protein_q",
             "ms1_intensity",
             "ms2_intensity",
-            // "ms1_apex_intensity",
         ]);
 
         wtr.write_byte_record(&headers)?;
@@ -159,7 +159,6 @@ impl Runner {
         record.push_field(itoa::Buffer::new().format(idx).as_bytes());
         record.push_field(itoa::Buffer::new().format(feature.label).as_bytes());
         record.push_field(scannr.as_bytes());
-        // record.push_field(feature.spec_id.as_bytes());
         record.push_field(ryu::Buffer::new().format(feature.expmass).as_bytes());
         record.push_field(ryu::Buffer::new().format(feature.calcmass).as_bytes());
         record.push_field(filenames[feature.file_id].as_bytes());
@@ -250,7 +249,11 @@ impl Runner {
                 .as_bytes(),
         );
         record.push_field(peptide.to_string().as_bytes());
-        record.push_field(peptide.proteins(&self.database.decoy_tag).as_bytes());
+        record.push_field(
+            peptide
+                .proteins(&self.database.decoy_tag, self.database.generate_decoys)
+                .as_bytes(),
+        );
         record
     }
 
@@ -388,9 +391,8 @@ impl Runner {
                 let mut record = csv::ByteRecord::new();
                 record.push_field(self.database[peptide_ix].to_string().as_bytes());
                 record.push_field(
-                    self.database
-                        .assign_proteins(&self.database[peptide_ix])
-                        .1
+                    self.database[peptide_ix]
+                        .proteins(&self.database.decoy_tag, self.database.generate_decoys)
                         .as_bytes(),
                 );
                 record.push_field(ryu::Buffer::new().format(peak.q_value).as_bytes());

--- a/crates/sage-cli/src/output.rs
+++ b/crates/sage-cli/src/output.rs
@@ -8,9 +8,17 @@ use crate::Runner;
 impl Runner {
     pub fn serialize_feature(&self, feature: &Feature, filenames: &[String]) -> csv::ByteRecord {
         let mut record = csv::ByteRecord::new();
-        record.push_field(feature.peptide.as_str().as_bytes());
-        record.push_field(feature.proteins.as_str().as_bytes());
-        record.push_field(itoa::Buffer::new().format(feature.num_proteins).as_bytes());
+        let peptide = &self.database[feature.peptide_idx];
+        record.push_field(peptide.to_string().as_bytes());
+        record.push_field(peptide.proteins(&self.database.decoy_tag).as_bytes());
+        record.push_field(
+            itoa::Buffer::new()
+                .format(peptide.proteins.len())
+                .as_bytes(),
+        );
+        // record.push_field(feature.peptide.as_str().as_bytes());
+        // record.push_field(feature.proteins.as_str().as_bytes());
+        // record.push_field(itoa::Buffer::new().format(feature.num_proteins).as_bytes());
         record.push_field(filenames[feature.file_id].as_bytes());
         record.push_field(feature.spec_id.as_bytes());
         record.push_field(itoa::Buffer::new().format(feature.rank).as_bytes());
@@ -147,6 +155,7 @@ impl Runner {
             .unwrap_or(&feature.spec_id);
 
         let mut record = csv::ByteRecord::new();
+        let peptide = &self.database[feature.peptide_idx];
         record.push_field(itoa::Buffer::new().format(idx).as_bytes());
         record.push_field(itoa::Buffer::new().format(feature.label).as_bytes());
         record.push_field(scannr.as_bytes());
@@ -240,8 +249,8 @@ impl Runner {
                 .format((-feature.poisson).ln_1p())
                 .as_bytes(),
         );
-        record.push_field(feature.peptide.as_str().as_bytes());
-        record.push_field(feature.proteins.as_str().as_bytes());
+        record.push_field(peptide.to_string().as_bytes());
+        record.push_field(peptide.proteins(&self.database.decoy_tag).as_bytes());
         record
     }
 

--- a/crates/sage-cli/tests/integration.rs
+++ b/crates/sage-cli/tests/integration.rs
@@ -13,15 +13,15 @@ fn integration() -> anyhow::Result<()> {
     let database = builder.make_parameters().build()?;
     let pep = Peptide::try_from(Digest {
         sequence: "LQSRPAAPPAPGPGQLTLR".into(),
-        decoy: false,
-        missed_cleavages: 0,
-        position: sage_core::enzyme::Position::Internal,
+        ..Default::default()
     })
     .unwrap();
-    assert_eq!(
-        database.assign_proteins(&pep),
-        (1, "sp|Q99536|VAT1_HUMAN".into())
-    );
+
+    dbg!(&pep);
+    // assert_eq!(
+    //     database.assign_proteins(&pep),
+    //     (1, "sp|Q99536|VAT1_HUMAN".into())
+    // );
 
     let spectra = sage_core::read_mzml("../../tests/LQSRPAAPPAPGPGQLTLR.mzML", None)?;
     assert_eq!(spectra.len(), 1);
@@ -46,7 +46,6 @@ fn integration() -> anyhow::Result<()> {
 
     let psm = scorer.score(&processed, 1);
     assert_eq!(psm.len(), 1);
-    assert_eq!(psm[0].peptide, "LQSRPAAPPAPGPGQLTLR");
     assert_eq!(psm[0].matched_peaks, 21);
 
     Ok(())

--- a/crates/sage-cli/tests/integration.rs
+++ b/crates/sage-cli/tests/integration.rs
@@ -17,12 +17,6 @@ fn integration() -> anyhow::Result<()> {
     })
     .unwrap();
 
-    dbg!(&pep);
-    // assert_eq!(
-    //     database.assign_proteins(&pep),
-    //     (1, "sp|Q99536|VAT1_HUMAN".into())
-    // );
-
     let spectra = sage_core::read_mzml("../../tests/LQSRPAAPPAPGPGQLTLR.mzML", None)?;
     assert_eq!(spectra.len(), 1);
 

--- a/crates/sage-cli/tests/integration.rs
+++ b/crates/sage-cli/tests/integration.rs
@@ -1,5 +1,7 @@
 use sage_core::database::Builder;
+use sage_core::enzyme::Digest;
 use sage_core::mass::Tolerance;
+use sage_core::peptide::Peptide;
 use sage_core::scoring::Scorer;
 use sage_core::spectrum::SpectrumProcessor;
 
@@ -9,6 +11,17 @@ fn integration() -> anyhow::Result<()> {
     builder.update_fasta("../../tests/Q99536.fasta".into());
 
     let database = builder.make_parameters().build()?;
+    let pep = Peptide::try_from(Digest {
+        sequence: "LQSRPAAPPAPGPGQLTLR".into(),
+        decoy: false,
+        missed_cleavages: 0,
+        position: sage_core::enzyme::Position::Internal,
+    })
+    .unwrap();
+    assert_eq!(
+        database.assign_proteins(&pep),
+        (1, "sp|Q99536|VAT1_HUMAN".into())
+    );
 
     let spectra = sage_core::read_mzml("../../tests/LQSRPAAPPAPGPGQLTLR.mzML", None)?;
     assert_eq!(spectra.len(), 1);

--- a/crates/sage/src/enzyme.rs
+++ b/crates/sage/src/enzyme.rs
@@ -1,5 +1,6 @@
 use fnv::FnvHashSet;
 use regex::Regex;
+use std::sync::Arc;
 
 use crate::mass::VALID_AA;
 
@@ -14,6 +15,8 @@ pub struct Digest {
     pub decoy: bool,
     /// Cleaved peptide sequence
     pub sequence: String,
+    /// Protein accession
+    pub protein: Arc<String>,
     /// Missed cleavages
     pub missed_cleavages: u8,
     /// Is this an N-terminal peptide of the protein?
@@ -48,6 +51,7 @@ impl Digest {
 
         Digest {
             decoy: true,
+            protein: self.protein.clone(),
             sequence: sequence.into_iter().collect(),
             missed_cleavages: self.missed_cleavages,
             position: self.position,
@@ -162,7 +166,7 @@ impl EnzymeParameters {
         }
     }
 
-    pub fn digest(&self, sequence: &str) -> Vec<Digest> {
+    pub fn digest(&self, sequence: &str, protein: Arc<String>) -> Vec<Digest> {
         let n = sequence.len();
         let mut digests = Vec::new();
         let sites = self.cleavage_sites(sequence);
@@ -203,6 +207,7 @@ impl EnzymeParameters {
                         missed_cleavages: cleavage - 1,
                         decoy: false,
                         position,
+                        protein: protein.clone(),
                     });
                 }
             }
@@ -225,12 +230,14 @@ mod test {
                 sequence: "MADEEK".into(),
                 missed_cleavages: 0,
                 position: Position::Nterm,
+                protein: Arc::new(String::default()),
             },
             Digest {
                 decoy: false,
                 sequence: "MADEEK".into(),
                 missed_cleavages: 0,
                 position: Position::Nterm,
+                protein: Arc::new(String::default()),
             },
         ];
 
@@ -244,12 +251,14 @@ mod test {
                 sequence: "MADEEK".into(),
                 missed_cleavages: 0,
                 position: Position::Nterm,
+                protein: Arc::new(String::default()),
             },
             Digest {
                 decoy: false,
                 sequence: "MADEEK".into(),
                 missed_cleavages: 0,
                 position: Position::Internal,
+                protein: Arc::new(String::default()),
             },
         ];
 
@@ -278,7 +287,7 @@ mod test {
 
         assert_eq!(
             expected,
-            tryp.digest(sequence)
+            tryp.digest(sequence, Arc::default())
                 .into_iter()
                 .map(|d| (d.sequence, d.position))
                 .collect::<Vec<_>>()
@@ -311,7 +320,7 @@ mod test {
 
         assert_eq!(
             expected,
-            tryp.digest(sequence)
+            tryp.digest(sequence, Arc::default())
                 .into_iter()
                 .map(|d| d.sequence)
                 .collect::<Vec<_>>()
@@ -348,7 +357,7 @@ mod test {
 
         assert_eq!(
             expected,
-            tryp.digest(sequence)
+            tryp.digest(sequence, Arc::default())
                 .into_iter()
                 .map(|d| d.sequence)
                 .collect::<Vec<_>>()
@@ -376,7 +385,7 @@ mod test {
 
         assert_eq!(
             expected,
-            tryp.digest(sequence)
+            tryp.digest(sequence, Arc::default())
                 .into_iter()
                 .map(|d| d.sequence)
                 .collect::<Vec<_>>()
@@ -397,7 +406,7 @@ mod test {
 
         assert_eq!(
             expected,
-            tryp.digest(sequence)
+            tryp.digest(sequence, Arc::default())
                 .into_iter()
                 .map(|d| d.sequence)
                 .collect::<Vec<_>>()
@@ -426,7 +435,7 @@ mod test {
 
         assert_eq!(
             expected,
-            tryp.digest(sequence)
+            tryp.digest(sequence, Arc::default())
                 .into_iter()
                 .map(|d| d.sequence)
                 .collect::<Vec<_>>()
@@ -452,7 +461,7 @@ mod test {
 
         assert_eq!(
             expected,
-            tryp.digest(sequence)
+            tryp.digest(sequence, Arc::default())
                 .into_iter()
                 .map(|d| d.sequence)
                 .collect::<Vec<_>>()
@@ -481,7 +490,7 @@ mod test {
 
         assert_eq!(
             expected,
-            tryp.digest(sequence)
+            tryp.digest(sequence, Arc::default())
                 .into_iter()
                 .map(|d| d.sequence)
                 .collect::<Vec<_>>()
@@ -502,7 +511,7 @@ mod test {
 
         assert_eq!(
             expected,
-            tryp.digest(sequence)
+            tryp.digest(sequence, Arc::default())
                 .into_iter()
                 .map(|d| d.sequence)
                 .collect::<Vec<_>>()
@@ -523,7 +532,7 @@ mod test {
 
         assert_eq!(
             expected,
-            tryp.digest(sequence)
+            tryp.digest(sequence, Arc::default())
                 .into_iter()
                 .map(|d| d.sequence)
                 .collect::<Vec<_>>()

--- a/crates/sage/src/ion_series.rs
+++ b/crates/sage/src/ion_series.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::mass::Mass;
+use crate::mass::monoisotopic;
 use crate::peptide::Peptide;
 
 #[derive(Copy, Clone, Debug, PartialEq, PartialOrd, Deserialize, Serialize)]
@@ -73,8 +73,8 @@ impl<'p> Iterator for IonSeries<'p> {
         let m = self.peptide.modifications[self.idx];
 
         self.cumulative_mass += match self.kind {
-            Kind::A | Kind::B | Kind::C => r.monoisotopic() + m,
-            Kind::X | Kind::Y | Kind::Z => -(r.monoisotopic() + m),
+            Kind::A | Kind::B | Kind::C => monoisotopic(r) + m,
+            Kind::X | Kind::Y | Kind::Z => -(monoisotopic(r) + m),
         };
         self.idx += 1;
 

--- a/crates/sage/src/lfq.rs
+++ b/crates/sage/src/lfq.rs
@@ -1,5 +1,5 @@
 use crate::database::{binary_search_slice, IndexedDatabase, PeptideIx};
-use crate::mass::{Composition, Mass, Tolerance, NEUTRON};
+use crate::mass::{composition, Composition, Tolerance, NEUTRON};
 use crate::ml::{matrix::Matrix, retention_alignment::Alignment};
 use crate::scoring::Feature;
 use crate::spectrum::ProcessedSpectrum;
@@ -221,7 +221,7 @@ impl FeatureMap {
                                     let composition = p
                                         .sequence
                                         .iter()
-                                        .map(|r| r.composition())
+                                        .map(|r| composition(*r))
                                         .sum::<Composition>();
                                     let dist = crate::isotopes::peptide_isotopes(
                                         composition.carbon,

--- a/crates/sage/src/lfq.rs
+++ b/crates/sage/src/lfq.rs
@@ -220,7 +220,6 @@ impl FeatureMap {
                                     let p = &db[entry.peptide];
                                     let composition = p
                                         .sequence
-                                        .as_bytes()
                                         .iter()
                                         .map(|r| r.composition())
                                         .sum::<Composition>();

--- a/crates/sage/src/lfq.rs
+++ b/crates/sage/src/lfq.rs
@@ -220,6 +220,7 @@ impl FeatureMap {
                                     let p = &db[entry.peptide];
                                     let composition = p
                                         .sequence
+                                        .as_bytes()
                                         .iter()
                                         .map(|r| r.composition())
                                         .sum::<Composition>();

--- a/crates/sage/src/lib.rs
+++ b/crates/sage/src/lib.rs
@@ -7,6 +7,7 @@ pub mod isotopes;
 pub mod lfq;
 pub mod mass;
 pub mod ml;
+pub mod modification;
 pub mod mzml;
 pub mod peptide;
 pub mod scoring;

--- a/crates/sage/src/mass.rs
+++ b/crates/sage/src/mass.rs
@@ -49,11 +49,6 @@ impl Mul<f32> for Tolerance {
     }
 }
 
-pub trait Mass {
-    fn monoisotopic(&self) -> f32;
-    fn composition(&self) -> Composition;
-}
-
 pub const VALID_AA: [u8; 22] = [
     b'A', b'C', b'D', b'E', b'F', b'G', b'H', b'I', b'K', b'L', b'M', b'N', b'P', b'Q', b'R', b'S',
     b'T', b'V', b'W', b'Y', b'U', b'O',
@@ -65,68 +60,39 @@ pub const MONOISOTOPIC_MASSES: [f32; 26] = [
     101.04768, 150.95363, 99.06841, 186.07932, 0.0, 163.06332, 0.0,
 ];
 
-impl Mass for u8 {
-    fn monoisotopic(&self) -> f32 {
-        if self.is_ascii_uppercase() {
-            MONOISOTOPIC_MASSES[(self - b'A') as usize]
-        } else {
-            0.0
-        }
+pub const fn monoisotopic(aa: u8) -> f32 {
+    if aa.is_ascii_uppercase() {
+        MONOISOTOPIC_MASSES[(aa - b'A') as usize]
+    } else {
+        0.0
     }
-    // fn monoisotopic(&self) -> f32 {
-    //     match self {
-    //         b'A' => 71.03711,
-    //         b'R' => 156.1011,
-    //         b'N' => 114.04293,
-    //         b'D' => 115.02694,
-    //         b'C' => 103.00919,
-    //         b'E' => 129.04259,
-    //         b'Q' => 128.05858,
-    //         b'G' => 57.02146,
-    //         b'H' => 137.05891,
-    //         b'I' => 113.08406,
-    //         b'L' => 113.08406,
-    //         b'K' => 128.09496,
-    //         b'M' => 131.0405,
-    //         b'F' => 147.0684,
-    //         b'P' => 97.05276,
-    //         b'S' => 87.03203,
-    //         b'T' => 101.04768,
-    //         b'W' => 186.07931,
-    //         b'Y' => 163.06333,
-    //         b'V' => 99.06841,
-    //         b'U' => 150.95363,
-    //         b'O' => 237.14773,
-    //         _ => unreachable!("BUG: invalid amino acid {}", *self as char),
-    //     }
-    // }
+}
 
-    fn composition(&self) -> Composition {
-        match self {
-            b'A' => Composition::new(3, 2, 0),
-            b'R' => Composition::new(6, 2, 0),
-            b'N' => Composition::new(4, 3, 0),
-            b'D' => Composition::new(4, 4, 0),
-            b'C' => Composition::new(3, 2, 1),
-            b'E' => Composition::new(5, 4, 0),
-            b'Q' => Composition::new(5, 3, 0),
-            b'G' => Composition::new(2, 2, 0),
-            b'H' => Composition::new(6, 2, 0),
-            b'I' => Composition::new(6, 2, 0),
-            b'L' => Composition::new(6, 2, 0),
-            b'K' => Composition::new(6, 2, 0),
-            b'M' => Composition::new(5, 2, 1),
-            b'F' => Composition::new(9, 2, 0),
-            b'P' => Composition::new(5, 2, 0),
-            b'S' => Composition::new(3, 3, 0),
-            b'T' => Composition::new(4, 3, 0),
-            b'W' => Composition::new(11, 2, 0),
-            b'Y' => Composition::new(9, 3, 0),
-            b'V' => Composition::new(5, 2, 0),
-            b'U' => Composition::new(3, 2, 0),
-            b'O' => Composition::new(12, 3, 0),
-            _ => unreachable!("BUG: invalid amino acid {}", *self as char),
-        }
+pub const fn composition(aa: u8) -> Composition {
+    match aa {
+        b'A' => Composition::new(3, 2, 0),
+        b'R' => Composition::new(6, 2, 0),
+        b'N' => Composition::new(4, 3, 0),
+        b'D' => Composition::new(4, 4, 0),
+        b'C' => Composition::new(3, 2, 1),
+        b'E' => Composition::new(5, 4, 0),
+        b'Q' => Composition::new(5, 3, 0),
+        b'G' => Composition::new(2, 2, 0),
+        b'H' => Composition::new(6, 2, 0),
+        b'I' => Composition::new(6, 2, 0),
+        b'L' => Composition::new(6, 2, 0),
+        b'K' => Composition::new(6, 2, 0),
+        b'M' => Composition::new(5, 2, 1),
+        b'F' => Composition::new(9, 2, 0),
+        b'P' => Composition::new(5, 2, 0),
+        b'S' => Composition::new(3, 3, 0),
+        b'T' => Composition::new(4, 3, 0),
+        b'W' => Composition::new(11, 2, 0),
+        b'Y' => Composition::new(9, 3, 0),
+        b'V' => Composition::new(5, 2, 0),
+        b'U' => Composition::new(3, 2, 0),
+        b'O' => Composition::new(12, 3, 0),
+        _ => Composition::new(0, 0, 0),
     }
 }
 
@@ -155,12 +121,14 @@ impl Sum for Composition {
 
 #[cfg(test)]
 mod test {
-    use super::{Mass, Tolerance, VALID_AA};
+    use crate::mass::monoisotopic;
+
+    use super::{Tolerance, VALID_AA};
 
     #[test]
     fn smoke() {
         for ch in VALID_AA {
-            assert!(ch.monoisotopic() > 0.0);
+            assert!(monoisotopic(ch) > 0.0);
         }
     }
 

--- a/crates/sage/src/mass.rs
+++ b/crates/sage/src/mass.rs
@@ -54,63 +54,52 @@ pub trait Mass {
     fn composition(&self) -> Composition;
 }
 
-#[derive(Clone, Debug, PartialEq, PartialOrd, Serialize)]
-pub enum Residue {
-    // Standard amino acid residue
-    Just(u8),
-    // Amino acid residue with a mass modification
-    Mod(u8, f32),
-}
-
-impl Mass for Residue {
-    fn monoisotopic(&self) -> f32 {
-        match self {
-            Residue::Just(c) => c.monoisotopic(),
-            Residue::Mod(c, m) => c.monoisotopic() + m,
-        }
-    }
-
-    fn composition(&self) -> Composition {
-        match self {
-            Residue::Just(c) => c.composition(),
-            Residue::Mod(c, _) => c.composition(),
-        }
-    }
-}
-
 pub const VALID_AA: [u8; 22] = [
     b'A', b'C', b'D', b'E', b'F', b'G', b'H', b'I', b'K', b'L', b'M', b'N', b'P', b'Q', b'R', b'S',
     b'T', b'V', b'W', b'Y', b'U', b'O',
 ];
 
+pub const MONOISOTOPIC_MASSES: [f32; 26] = [
+    71.03711, 0.0, 103.00919, 115.02694, 129.04259, 147.0684, 57.02146, 137.05891, 113.08406, 0.0,
+    128.09496, 113.08406, 131.0405, 114.04293, 237.14774, 97.05276, 128.05858, 156.1011, 87.03203,
+    101.04768, 150.95363, 99.06841, 186.07932, 0.0, 163.06332, 0.0,
+];
+
 impl Mass for u8 {
     fn monoisotopic(&self) -> f32 {
-        match self {
-            b'A' => 71.03711,
-            b'R' => 156.1011,
-            b'N' => 114.04293,
-            b'D' => 115.02694,
-            b'C' => 103.00919,
-            b'E' => 129.04259,
-            b'Q' => 128.05858,
-            b'G' => 57.02146,
-            b'H' => 137.05891,
-            b'I' => 113.08406,
-            b'L' => 113.08406,
-            b'K' => 128.09496,
-            b'M' => 131.0405,
-            b'F' => 147.0684,
-            b'P' => 97.05276,
-            b'S' => 87.03203,
-            b'T' => 101.04768,
-            b'W' => 186.07931,
-            b'Y' => 163.06333,
-            b'V' => 99.06841,
-            b'U' => 150.95363,
-            b'O' => 237.14773,
-            _ => unreachable!("BUG: invalid amino acid {}", *self as char),
+        if self.is_ascii_uppercase() {
+            MONOISOTOPIC_MASSES[(self - b'A') as usize]
+        } else {
+            panic!("invalid AA: {}", self)
         }
     }
+    // fn monoisotopic(&self) -> f32 {
+    //     match self {
+    //         b'A' => 71.03711,
+    //         b'R' => 156.1011,
+    //         b'N' => 114.04293,
+    //         b'D' => 115.02694,
+    //         b'C' => 103.00919,
+    //         b'E' => 129.04259,
+    //         b'Q' => 128.05858,
+    //         b'G' => 57.02146,
+    //         b'H' => 137.05891,
+    //         b'I' => 113.08406,
+    //         b'L' => 113.08406,
+    //         b'K' => 128.09496,
+    //         b'M' => 131.0405,
+    //         b'F' => 147.0684,
+    //         b'P' => 97.05276,
+    //         b'S' => 87.03203,
+    //         b'T' => 101.04768,
+    //         b'W' => 186.07931,
+    //         b'Y' => 163.06333,
+    //         b'V' => 99.06841,
+    //         b'U' => 150.95363,
+    //         b'O' => 237.14773,
+    //         _ => unreachable!("BUG: invalid amino acid {}", *self as char),
+    //     }
+    // }
 
     fn composition(&self) -> Composition {
         match self {
@@ -161,21 +150,6 @@ impl Sum for Composition {
             comp.sulfur += i.sulfur;
         }
         comp
-    }
-}
-
-impl std::fmt::Display for Residue {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Residue::Just(c) => f.write_char(*c as char),
-            Residue::Mod(c, m) => {
-                if m.is_sign_positive() {
-                    write!(f, "{}[+{}]", *c as char, m)
-                } else {
-                    write!(f, "{}[{}]", *c as char, m)
-                }
-            }
-        }
     }
 }
 

--- a/crates/sage/src/mass.rs
+++ b/crates/sage/src/mass.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Write, iter::Sum, ops::Mul};
+use std::{iter::Sum, ops::Mul};
 
 use serde::{Deserialize, Serialize};
 
@@ -70,7 +70,7 @@ impl Mass for u8 {
         if self.is_ascii_uppercase() {
             MONOISOTOPIC_MASSES[(self - b'A') as usize]
         } else {
-            panic!("invalid AA: {}", self)
+            0.0
         }
     }
     // fn monoisotopic(&self) -> f32 {

--- a/crates/sage/src/ml/retention_model.rs
+++ b/crates/sage/src/ml/retention_model.rs
@@ -42,7 +42,7 @@ impl RetentionModel {
     fn embed(peptide: &Peptide, map: &[usize; 26]) -> [f64; FEATURES] {
         let mut embedding = [0.0; FEATURES];
         let cterm = peptide.sequence.len().saturating_sub(3);
-        for (aa_idx, residue) in peptide.sequence.as_bytes().iter().enumerate() {
+        for (aa_idx, residue) in peptide.sequence.iter().enumerate() {
             let idx = map[(residue - b'A') as usize];
             embedding[idx] += 1.0;
             // Embed N- and C-terminal AA's (2 on each end, excluding K/R)

--- a/crates/sage/src/ml/retention_model.rs
+++ b/crates/sage/src/ml/retention_model.rs
@@ -42,12 +42,8 @@ impl RetentionModel {
     fn embed(peptide: &Peptide, map: &[usize; 26]) -> [f64; FEATURES] {
         let mut embedding = [0.0; FEATURES];
         let cterm = peptide.sequence.len().saturating_sub(3);
-        for (aa_idx, residue) in peptide.sequence.iter().enumerate() {
-            let c = match residue {
-                crate::mass::Residue::Just(c) => c,
-                crate::mass::Residue::Mod(c, _) => c,
-            };
-            let idx = map[(c - b'A') as usize];
+        for (aa_idx, residue) in peptide.sequence.as_bytes().iter().enumerate() {
+            let idx = map[(residue - b'A') as usize];
             embedding[idx] += 1.0;
             // Embed N- and C-terminal AA's (2 on each end, excluding K/R)
             match aa_idx {

--- a/crates/sage/src/modification.rs
+++ b/crates/sage/src/modification.rs
@@ -1,0 +1,234 @@
+use std::{
+    collections::HashMap,
+    fmt::{Display, Write},
+    str::FromStr,
+};
+
+use serde::{de::Visitor, Deserialize, Serialize};
+
+use crate::mass::VALID_AA;
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum ModificationSpecificity {
+    PeptideN(Option<u8>),
+    PeptideC(Option<u8>),
+    ProteinN(Option<u8>),
+    ProteinC(Option<u8>),
+    Residue(u8),
+}
+
+impl Display for ModificationSpecificity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let r = match self {
+            ModificationSpecificity::PeptideN(r) => {
+                f.write_char('^')?;
+                *r
+            }
+            ModificationSpecificity::PeptideC(r) => {
+                f.write_char('$')?;
+                *r
+            }
+            ModificationSpecificity::ProteinN(r) => {
+                f.write_char('[')?;
+                *r
+            }
+            ModificationSpecificity::ProteinC(r) => {
+                f.write_char(']')?;
+                *r
+            }
+            ModificationSpecificity::Residue(r) => Some(*r),
+        };
+
+        if let Some(r) = r {
+            f.write_char(r as char)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl Serialize for ModificationSpecificity {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum InvalidModification {
+    Empty,
+    InvalidResidue(char),
+    TooLong(String),
+}
+
+impl FromStr for ModificationSpecificity {
+    type Err = InvalidModification;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.len() > 2 {
+            return Err(InvalidModification::TooLong(s.into()));
+        }
+        if let Some(rest) = s.strip_prefix('^') {
+            return Ok(ModificationSpecificity::PeptideN(
+                rest.chars().next().map(|ch| ch as u8),
+            ));
+        }
+        if let Some(rest) = s.strip_prefix('$') {
+            return Ok(ModificationSpecificity::PeptideC(
+                rest.chars().next().map(|ch| ch as u8),
+            ));
+        }
+        if let Some(rest) = s.strip_prefix('[') {
+            return Ok(ModificationSpecificity::ProteinN(
+                rest.chars().next().map(|ch| ch as u8),
+            ));
+        }
+        if let Some(rest) = s.strip_prefix(']') {
+            return Ok(ModificationSpecificity::ProteinC(
+                rest.chars().next().map(|ch| ch as u8),
+            ));
+        }
+        match s.chars().next() {
+            Some(c) => {
+                if VALID_AA.contains(&(c as u8)) {
+                    Ok(ModificationSpecificity::Residue(c as u8))
+                } else {
+                    Err(InvalidModification::InvalidResidue(c))
+                }
+            }
+            None => Err(InvalidModification::Empty),
+        }
+    }
+}
+
+pub fn validate_mods(input: Option<HashMap<String, f32>>) -> HashMap<ModificationSpecificity, f32> {
+    let mut output = HashMap::new();
+    if let Some(input) = input {
+        for (s, mass) in input {
+            match ModificationSpecificity::from_str(&s) {
+                Ok(m) => {
+                    output.insert(m, mass);
+                }
+                Err(InvalidModification::Empty) => {
+                    log::error!("Invalid modification string: empty")
+                }
+                Err(InvalidModification::InvalidResidue(c)) => {
+                    log::error!("Invalid modification string: unrecognized residue ({})", c)
+                }
+                Err(InvalidModification::TooLong(s)) => {
+                    log::error!("Invalid modification string: {} is too long", s)
+                }
+            }
+        }
+    }
+    output
+}
+
+pub fn validate_var_mods(
+    input: Option<HashMap<String, ValueOrVec>>,
+) -> HashMap<ModificationSpecificity, Vec<f32>> {
+    let mut output = HashMap::new();
+    if let Some(input) = input {
+        for (s, mass) in input {
+            match ModificationSpecificity::from_str(&s) {
+                Ok(m) => {
+                    output.insert(m, mass.data);
+                }
+                Err(InvalidModification::Empty) => {
+                    log::error!("Skipping invalid modification string: empty")
+                }
+                Err(InvalidModification::InvalidResidue(c)) => {
+                    log::error!(
+                        "Skipping invalid modification string: unrecognized residue ({})",
+                        c
+                    )
+                }
+                Err(InvalidModification::TooLong(s)) => {
+                    log::error!("Skipping invalid modification string: {} is too long", s)
+                }
+            }
+        }
+    }
+    output
+}
+
+#[derive(Default)]
+pub struct ValueOrVec {
+    data: Vec<f32>,
+}
+
+impl<'de> Deserialize<'de> for ValueOrVec {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(ValueOrVec::default())
+    }
+}
+
+impl<'de> Visitor<'de> for ValueOrVec {
+    type Value = ValueOrVec;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        formatter.write_str("Expected floating point value, or list of floating point values")
+    }
+
+    fn visit_seq<A>(mut self, mut seq: A) -> Result<Self::Value, A::Error>
+    where
+        A: serde::de::SeqAccess<'de>,
+    {
+        while let Some(val) = seq.next_element::<f32>()? {
+            self.data.push(val);
+        }
+        Ok(self)
+    }
+
+    fn visit_f64<E>(mut self, v: f64) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        log::warn!(
+            "Single value variable modifications will be phased out. Use a list of modifications"
+        );
+        self.data.push(v as f32);
+        Ok(self)
+    }
+
+    fn visit_i64<E>(mut self, v: i64) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        log::warn!(
+            "Single value variable modifications will be phased out. Use a list of modifications"
+        );
+        self.data.push(v as f32);
+        Ok(self)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn parse_modifications() {
+        use InvalidModification::*;
+        use ModificationSpecificity::*;
+        assert_eq!("[".parse::<ModificationSpecificity>(), Ok(ProteinN(None)));
+        assert_eq!(
+            "[M".parse::<ModificationSpecificity>(),
+            Ok(ProteinN(Some(b'M')))
+        );
+        assert_eq!(
+            "]M".parse::<ModificationSpecificity>(),
+            Ok(ProteinC(Some(b'M')))
+        );
+        assert_eq!("M".parse::<ModificationSpecificity>(), Ok(Residue(b'M')));
+        assert_eq!(
+            "Z".parse::<ModificationSpecificity>(),
+            Err(InvalidResidue('Z'))
+        );
+    }
+}

--- a/crates/sage/src/scoring.rs
+++ b/crates/sage/src/scoring.rs
@@ -55,14 +55,7 @@ impl AddAssign<InitialHits> for InitialHits {
 pub struct Feature {
     #[serde(skip_serializing)]
     pub peptide_idx: PeptideIx,
-    /// Peptide sequence, including modifications e.g.: NC(+57.021)HK
-    pub peptide: String,
-    /// Peptide length
     pub peptide_len: usize,
-    /// Proteins containing this peptide sequence
-    pub proteins: String,
-    /// Number of proteins assigned to this peptide sequence
-    pub num_proteins: usize,
     /// Spectrum id
     pub spec_id: String,
     /// File identifier
@@ -124,8 +117,6 @@ pub struct Feature {
 
     pub ms2_intensity: f32,
     pub ms1_intensity: f32,
-    // pub ms1_apex: f32,
-    // pub ms1_apex_rt: f32,
 }
 
 /// Stirling's approximation for log factorial
@@ -401,14 +392,11 @@ impl<'db> Scorer<'db> {
             let delta_mass = (precursor_mass - peptide.monoisotopic - isotope_error).abs() * 2E6
                 / (precursor_mass - isotope_error + peptide.monoisotopic);
 
-            let (num_proteins, proteins) = self.db.assign_proteins(peptide);
+            // let (num_proteins, proteins) = self.db.assign_proteins(peptide);
 
             features.push(Feature {
                 // Identifiers
                 peptide_idx: score.peptide,
-                peptide: peptide.to_string(),
-                proteins,
-                num_proteins,
                 spec_id: query.id.clone(),
                 file_id: query.file_id,
                 rank: idx as u32 + 1,


### PR DESCRIPTION
This PR adds support for multiple variable modifications, and peptide/protein-terminal modifications that are specific to individual amino acids. This also overhauls both the internal data representation of `Peptide`, and how modifications are applied. This speeds up fragment index creation significantly (and should reduce memory usage), but it is still somewhat slow for large numbers of variable modifications - something to improve in the future!

The new syntax looks like this:
```json
"variable_mods": {
    "M": [15.9949],
    "^Q": -17.026549,
    "^E": -18.010565,
    "[": 42.010565
},
```

Either a single floating point number (`-18.0`) or a list of floating point numbers (`[-18.0, -15.2]`) can be supplied as modifications.

- "^X": Modification to be applied to amino acid X if it appears at the N-terminus of a peptide
- "$X": Modification to be applied to amino acid X if it appears at the C-terminus of a peptide
- "[X": Modification to be applied to amino acid X if it appears at the N-terminus of a protein
- "]X": Modification to be applied to amino acid X if it appears at the C-terminus of a protein

Modification strings without the "X" will be treated as before - applied to the N/C-terminus of the peptide itself.