### PR TITLE
TDF: Use spectrum index instead of precursor index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1630,6 +1630,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
+name = "memmap2"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2627,13 +2636,14 @@ dependencies = [
 
 [[package]]
 name = "timsrust"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d35d63d446ce6278d71949dfdf2d618c5891cdb4de7c1306e9631997d7916779"
+checksum = "9301709a549fabb2d79f564c528b0af5ca0002bdf0055341cfcc07950a44290b"
 dependencies = [
  "bytemuck",
  "byteorder",
  "linreg",
+ "memmap2",
  "parquet 42.0.0",
  "rayon",
  "rusqlite",

--- a/crates/sage-cloudpath/Cargo.toml
+++ b/crates/sage-cloudpath/Cargo.toml
@@ -23,7 +23,7 @@ log = "0.4.0"
 once_cell = "1.0"
 tokio = { version = "1.0", features = ["fs", "io-util", "rt", "macros"] }
 quick-xml = { version = "0.31.0", features = ["async-tokio"] }
-timsrust = "0.2.0"
+timsrust = "0.2.4"
 rayon = "1.5"
 reqwest = { version = "0.11", features = ["json", "rustls-tls"], default-features = false }
 regex = "1.6"

--- a/crates/sage-cloudpath/src/tdf.rs
+++ b/crates/sage-cloudpath/src/tdf.rs
@@ -33,7 +33,7 @@ impl TdfReader {
                     total_ion_current: 0.0,
                     mz: dda_spectrum.mz_values.iter().map(|&x| x as f32).collect(),
                     ms_level: 2,
-                    id: dda_precursor.index.to_string(),
+                    id: dda_spectrum.index.to_string(),
                     // precursor_id: dda_precursor.index as u32,
                     // frame_id: dda_precursor.frame_index as u32,
                     intensity: dda_spectrum.intensities.iter().map(|&x| x as f32).collect(),


### PR DESCRIPTION
Hi @lazear,

We had some issues matching Sage PSMs to spectra when read directly from TDF files. After conferring with @sander-willems-bruker, we found out there was some confusion in how precursor vs spectrum IDs are handled between different tools. For now, using the spectrum index seems to be the best way forward.

The PR also updates the timsrust version to 0.2.4.