### PR TITLE
Timsrust 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2376,18 +2376,18 @@ checksum = "a3f0bf26fd526d2a95683cd0f87bf103b8539e2ca1ef48ce002d67aad59aa0b4"
 
 [[package]]
 name = "serde"
-version = "1.0.197"
+version = "1.0.198"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+checksum = "9846a40c979031340571da2545a4e5b7c4163bdae79b301d5f86d03979451fcc"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.197"
+version = "1.0.198"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+checksum = "e88edab869b01783ba905e7d0153f9fc1a6505a96e4ad3018011eedb838566d9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2396,9 +2396,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.114"
+version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
+checksum = "3e17db7126d17feb94eb3fad46bf1a96b034e8aacbc2e775fe81505f8b0b2813"
 dependencies = [
  "itoa",
  "ryu",
@@ -2636,9 +2636,9 @@ dependencies = [
 
 [[package]]
 name = "timsrust"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9301709a549fabb2d79f564c528b0af5ca0002bdf0055341cfcc07950a44290b"
+checksum = "1da6a544bbe53188e4d2955f45edb5317437cf84cc05a24158b929a663e7f69c"
 dependencies = [
  "bytemuck",
  "byteorder",

--- a/crates/sage-cli/src/main.rs
+++ b/crates/sage-cli/src/main.rs
@@ -203,7 +203,7 @@ impl Runner {
             min_deisotope_mz.unwrap_or(0.0),
         );
 
-        let bruker_extensions = [".d", ".tdf", ".tdf_bin"];
+        let bruker_extensions = [".d", ".tdf", ".tdf_bin", "ms2", "raw"];
         let spectra = chunk
             .par_iter()
             .enumerate()
@@ -213,10 +213,16 @@ impl Runner {
                 let path_lower = path.to_lowercase();
                 let res = if path_lower.ends_with(".mgf.gz") || path_lower.ends_with(".mgf") {
                     sage_cloudpath::util::read_mgf(path, file_id)
-                } else if bruker_extensions
-                    .iter()
-                    .any(|ext| path_lower.ends_with(ext))
-                {
+                } else if bruker_extensions.iter().any(|ext| {
+                    if path_lower.ends_with(std::path::MAIN_SEPARATOR) {
+                        path_lower
+                            .strip_suffix(std::path::MAIN_SEPARATOR)
+                            .unwrap()
+                            .ends_with(ext)
+                    } else {
+                        path_lower.ends_with(ext)
+                    }
+                }) {
                     sage_cloudpath::util::read_tdf(path, file_id)
                 } else {
                     sage_cloudpath::util::read_mzml(path, file_id, sn)

--- a/crates/sage-cloudpath/Cargo.toml
+++ b/crates/sage-cloudpath/Cargo.toml
@@ -23,7 +23,7 @@ log = "0.4.0"
 once_cell = "1.0"
 tokio = { version = "1.0", features = ["fs", "io-util", "rt", "macros"] }
 quick-xml = { version = "0.31.0", features = ["async-tokio"] }
-timsrust = "0.2.4"
+timsrust = "0.3.0"
 rayon = "1.5"
 reqwest = { version = "0.11", features = ["json", "rustls-tls"], default-features = false }
 regex = "1.6"


### PR DESCRIPTION
PR that uses the latest toimsrust 0.3.0 package. This is major refactoring that 
* improves readability of timsrust code
* more clearly allows parallel spectrum reading
* allows to read diaPASEF windows as if they are spectra, allowing direct reading/processing of `raw_dia.d` data (results are not impressive compared to peptide centric searching though, but the mere capability is very useful for quick investigation of dia files).