### PR TITLE
update docker file to compile and create entrypoint for sage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,5 @@
-FROM debian:bullseye-slim
-
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends procps ca-certificates && \
-    update-ca-certificates && \
-    rm -rf /var/lib/apt /var/lib/dpkg /var/lib/cache /var/lib/log
-
+FROM rust
 WORKDIR /app
-
-COPY target/x86_64-unknown-linux-gnu/release/sage /app/sage
-
-ENV PATH="/app:$PATH"
+COPY . /app
+RUN cargo run --release tests/config.json
+ENTRYPOINT ["/app/target/release/sage"]


### PR DESCRIPTION
by following the "compile from source" https://sage-docs.vercel.app/docs/started and loaded up the created docker image to the hub https://hub.docker.com/repository/docker/animesh1977/sage/general, tested with local data `docker run --rm -it -v /home/data:/data animesh1977/sage /data/sage.json -f /data/human_crap.fasta -o /data /data/240624_200ngHelaQC_DDAlong_Slot1-54_1_7830.mzML /data/240624_200ngHelaQC_DDAlong_Slot1-54_1_7831.mzML /data/240624_200ngHelaQC_DDAlong_Slot1-54_1_7832.mzML /data/240605_200ngHelaQC_DDAlong_Slot1-54_1_7643.mzML /data/240605_200ngHelaQC_DDAlong_Slot1-54_1_7641.mzML` and it seems to produced results

```
ls -ltrh /home/data/
-rw-r--r-- 1 root   root   294M Jul 29 23:02 results.sage.tsv
-rw-r--r-- 1 root   root   1.8K Jul 29 23:02 results.json
-rw-r--r-- 1 root   root    13M Jul 29 23:02 lfq.tsv

```
