### PR TITLE
Db splitting

### DIFF
--- a/crates/sage-cli/src/input.rs
+++ b/crates/sage-cli/src/input.rs
@@ -10,7 +10,7 @@ use sage_core::{
 };
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize)]
+#[derive(Serialize, Clone)]
 /// Actual search parameters - may include overrides or default values not set by user
 pub struct Search {
     pub version: String,
@@ -148,7 +148,7 @@ pub struct QuantOptions {
     pub lfq_options: Option<LfqOptions>,
 }
 
-#[derive(Serialize, Default)]
+#[derive(Serialize, Default, Clone)]
 pub struct QuantSettings {
     pub tmt: Option<Isobaric>,
     pub tmt_settings: TmtSettings,

--- a/crates/sage-cli/src/main.rs
+++ b/crates/sage-cli/src/main.rs
@@ -1,10 +1,6 @@
 use clap::{value_parser, Arg, Command, ValueHint};
 use input::Input;
-
-mod input;
-mod output;
-mod runner;
-mod telemetry;
+use runner::Runner;
 
 fn main() -> anyhow::Result<()> {
     env_logger::Builder::default()
@@ -107,9 +103,11 @@ fn main() -> anyhow::Result<()> {
 
     let input = Input::from_arguments(matches)?;
 
-    let runner_ = input.build().and_then(runner::Runner::new)?;
+    let runner = input
+        .build()
+        .and_then(|parameters| Runner::new(parameters, parallel))?;
 
-    let tel = runner_.run(parallel, parquet)?;
+    let tel = runner.run(parallel, parquet)?;
 
     if send_telemetry {
         tel.send();

--- a/crates/sage/src/fasta.rs
+++ b/crates/sage/src/fasta.rs
@@ -77,4 +77,14 @@ impl Fasta {
             })
             .collect()
     }
+
+    pub fn iter_chunks(&self, chunk_size: usize) -> impl Iterator<Item = Self> + '_ {
+        self.targets
+            .chunks(chunk_size)
+            .map(move |target_chunk| Self {
+                targets: target_chunk.to_vec(),
+                decoy_tag: self.decoy_tag.clone(),
+                generate_decoys: self.generate_decoys,
+            })
+    }
 }


### PR DESCRIPTION
With this PR we allow the database to be split. This is especially helpful to control the memory for non-specific searches such as immuno, i.e. when setting `"cleave_at": ""` or many PTMs. The core concept is to iterate over fasta chunks rather than creating a db based on the whole fasta. Based on these chunks, only relevant peptides will be retained. After quickly filtering the database like this, all potential peptide hits are collected to make a final (severely) filtered database that is used for a native Sage search without any code alterations.

The memory seems to be very well controlled with this approach. The (identification) results are almost the same as doing searches without chunking, but for any specific chunk size there are some minor (generally <1%) differences as some scores (notably the Poisson score of features) rely on non-filtered databases.

New parameters (all optional) in the config are:
```
  "database": {
    "prefilter": true,
    "prefilter_chunk_size": 1000,
    "prefilter_low_memory": false,
   ...
```

* Prefilter is optional and defaults to false. If false, other prefilter params are ignored.
* Chunk size (i.e. number of fasta sequences to process simultaneously) defaults to 0, causing a panic when prefilter is set to true. Ideally, setting it to 0 automatically takes a reasonable chunk size to e.g. create chunks containing 1M-5M peptides which generally an be processed even on small machine with just 16GB RAM. This is not included in this PR though yet.
* The low memory mode (defaults to false) filters even more stringent and just keeps the top N + 1 PSM ranks after filtering, rather than the default (hard-coded) 50 top initial hits per PSM per chunk.

NOTE: this PR is made as a draft, as we hope to receive community feedback before merging into master.