### PR TITLE
Feat/ims lfq

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Get Cargo toolchain
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/upload_artifacts/action.yml
+++ b/.github/workflows/upload_artifacts/action.yml
@@ -18,7 +18,7 @@ runs:
   steps:
 
   - name: Upload build artifacts
-    uses: actions/upload-artifact@v3
+    uses: actions/upload-artifact@v4
     with:
       name: ${{ inputs.name }}
       path: ${{ inputs.path }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [v0.15.0-alpha] (unreleased)
 ### Added
+- Initial support for LFQ on data with ion mobility.
+- Speedup on the generation of databases when large number of peptides are redundant.
 - Initial support for searching diaPASEF data
 - `override_precursor_charge` setting that forces multiple charge states to be searched
 ### Breaking Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,9 +133,9 @@ checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
 name = "arrow-array"
-version = "42.0.0"
+version = "53.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea9a0fd21121304cad96f307c938d861cb1e7f0c151b93047462cd9817d760fb"
+checksum = "2d45fe6d3faed0435b7313e59a02583b14c6c6339fa7729e94c32a20af319a79"
 dependencies = [
  "ahash",
  "arrow-buffer",
@@ -143,42 +143,46 @@ dependencies = [
  "arrow-schema",
  "chrono",
  "half",
- "hashbrown",
+ "hashbrown 0.15.2",
  "num",
 ]
 
 [[package]]
 name = "arrow-buffer"
-version = "42.0.0"
+version = "53.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ce342ecf5971004e23cef8b5fb3bacd2bbc48a381464144925074e1472e9eb"
+checksum = "2b02656a35cc103f28084bc80a0159668e0a680d919cef127bd7e0aaccb06ec1"
 dependencies = [
+ "bytes",
  "half",
  "num",
 ]
 
 [[package]]
 name = "arrow-cast"
-version = "42.0.0"
+version = "53.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b94a0ce7d27abbb02e2ee4db770f593127610f57b32625b0bc6a1a90d65f085"
+checksum = "c73c6233c5b5d635a56f6010e6eb1ab9e30e94707db21cea03da317f67d84cf3"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
  "arrow-schema",
  "arrow-select",
+ "atoi",
+ "base64 0.22.1",
  "chrono",
  "half",
  "lexical-core",
  "num",
+ "ryu",
 ]
 
 [[package]]
 name = "arrow-data"
-version = "42.0.0"
+version = "53.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d9a83dad6a53d6907765106d3bc61d6d9d313cfe1751701b3ef0948e7283dc2"
+checksum = "b7f2861ffa86f107b8ab577d86cff7c7a490243eabe961ba1e1af4f27542bb79"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -188,9 +192,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
-version = "42.0.0"
+version = "53.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a46da5e438a854e0386b38774da88a98782c0973c6dbc5c949ca4e02faf9b016"
+checksum = "0270dc511f11bb5fa98a25020ad51a99ca5b08d8a8dfbd17503bb9dba0388f0b"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -202,16 +206,17 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "42.0.0"
+version = "53.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba9ed245bd2d7d97ad1457cb281d4296e8b593588758b8fec6d67b2b2b0f2265"
+checksum = "9579b9d8bce47aa41389fe344f2c6758279983b7c0ebb4013e283e3e91bb450e"
 
 [[package]]
 name = "arrow-select"
-version = "42.0.0"
+version = "53.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc9bd6aebc565b1d04bae64a0f4dda3abc677190eb7d960471b1b20e1cebed0"
+checksum = "7471ba126d0b0aaa24b50a36bc6c25e4e74869a1fd1a5553357027a0b1c8d1f1"
 dependencies = [
+ "ahash",
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
@@ -241,6 +246,15 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -664,6 +678,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "base64-simd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -696,9 +716,9 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "3.5.0"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d640d25bc63c50fb1f0b545ffd80207d2e10a4c965530809b40ba3386825c391"
+checksum = "cc97b8f16f944bba54f0433f07e30be199b6dc2bd25937444bbad560bcea29bd"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -707,9 +727,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "2.5.1"
+version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e2e4afe60d7dd600fdd3de8d0f08c2b7ec039712e3b6137ff98b7004e82de4f"
+checksum = "74fa05ad7d803d413eb8380983b092cbbaf9a85f151b871360e7b00cd7060b37"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -723,9 +743,9 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytemuck"
-version = "1.17.1"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773d90827bc3feecfb67fab12e24de0749aad83c74b9504ecde46237b5cd24e2"
+checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
 
 [[package]]
 name = "byteorder"
@@ -945,7 +965,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
  "cfg-if",
- "hashbrown",
+ "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
  "parking_lot_core",
@@ -1058,9 +1078,9 @@ dependencies = [
 
 [[package]]
 name = "flatbuffers"
-version = "23.5.26"
+version = "24.12.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dac53e22462d78c16d64a1cd22371b54cc3fe94aa15e7886a2fa6e5d1ab8640"
+checksum = "4f1baf0dbf96932ec9a3038d57900329c015b0bfb7b63d904f3bc27e2b02a096"
 dependencies = [
  "bitflags 1.3.2",
  "rustc_version",
@@ -1147,7 +1167,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1247,12 +1267,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+
+[[package]]
 name = "hashlink"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -1418,7 +1444,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -1489,9 +1515,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "lexical-core"
-version = "0.8.5"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cde5de06e8d4c2faabc400238f9ae1c74d5412d03a7bd067645ccbc47070e46"
+checksum = "b765c31809609075565a70b4b71402281283aeda7ecaf4818ac14a7b2ade8958"
 dependencies = [
  "lexical-parse-float",
  "lexical-parse-integer",
@@ -1502,9 +1528,9 @@ dependencies = [
 
 [[package]]
 name = "lexical-parse-float"
-version = "0.8.5"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683b3a5ebd0130b8fb52ba0bdc718cc56815b6a097e28ae5a6997d0ad17dc05f"
+checksum = "de6f9cb01fb0b08060209a057c048fcbab8717b4c1ecd2eac66ebfe39a65b0f2"
 dependencies = [
  "lexical-parse-integer",
  "lexical-util",
@@ -1513,9 +1539,9 @@ dependencies = [
 
 [[package]]
 name = "lexical-parse-integer"
-version = "0.8.6"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d0994485ed0c312f6d965766754ea177d07f9c00c9b82a5ee62ed5b47945ee9"
+checksum = "72207aae22fc0a121ba7b6d479e42cbfea549af1479c3f3a4f12c70dd66df12e"
 dependencies = [
  "lexical-util",
  "static_assertions",
@@ -1523,18 +1549,18 @@ dependencies = [
 
 [[package]]
 name = "lexical-util"
-version = "0.8.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5255b9ff16ff898710eb9eb63cb39248ea8a5bb036bea8085b1a767ff6c4e3fc"
+checksum = "5a82e24bf537fd24c177ffbbdc6ebcc8d54732c35b50a3f28cc3f4e4c949a0b3"
 dependencies = [
  "static_assertions",
 ]
 
 [[package]]
 name = "lexical-write-float"
-version = "0.8.5"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accabaa1c4581f05a3923d1b4cfd124c329352288b7b9da09e766b0668116862"
+checksum = "c5afc668a27f460fb45a81a757b6bf2f43c2d7e30cb5a2dcd3abf294c78d62bd"
 dependencies = [
  "lexical-util",
  "lexical-write-integer",
@@ -1543,9 +1569,9 @@ dependencies = [
 
 [[package]]
 name = "lexical-write-integer"
-version = "0.8.5"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1b6f3d1f4422866b68192d62f77bc5c700bee84f3069f2469d7bc8c77852446"
+checksum = "629ddff1a914a836fb245616a7888b62903aae58fa771e1d83943035efa0f978"
 dependencies = [
  "lexical-util",
  "static_assertions",
@@ -1565,9 +1591,9 @@ checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.28.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
  "cc",
  "pkg-config",
@@ -1601,23 +1627,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
-name = "lz4"
-version = "1.26.0"
+name = "lz4_flex"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958b4caa893816eea05507c20cfe47574a43d9a697138a7872990bba8a0ece68"
+checksum = "75761162ae2b0e580d7e7c390558127e5f01b4194debd6221fd8c207fc80e3f5"
 dependencies = [
- "libc",
- "lz4-sys",
-]
-
-[[package]]
-name = "lz4-sys"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "109de74d5d2353660401699a4174a4ff23fcc649caf553df71933c7fb45ad868"
-dependencies = [
- "cc",
- "libc",
+ "twox-hash",
 ]
 
 [[package]]
@@ -1831,9 +1846,29 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "42.0.0"
+version = "50.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baab9c36b1c8300b81b4d577d306a0a733f9d34021363098d3548e37757ed6c8"
+checksum = "547b92ebf0c1177e3892f44c8f79757ee62e678d564a9834189725f2c5b7a750"
+dependencies = [
+ "ahash",
+ "bytes",
+ "chrono",
+ "half",
+ "hashbrown 0.14.5",
+ "num",
+ "num-bigint",
+ "paste",
+ "seq-macro",
+ "thrift",
+ "twox-hash",
+ "zstd",
+]
+
+[[package]]
+name = "parquet"
+version = "53.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8957c0c95a6a1804f3e51a18f69df29be53856a8c5768cc9b6d00fcafcd2917c"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -1843,13 +1878,14 @@ dependencies = [
  "arrow-ipc",
  "arrow-schema",
  "arrow-select",
- "base64 0.21.7",
+ "base64 0.22.1",
  "brotli",
  "bytes",
  "chrono",
  "flate2",
- "hashbrown",
- "lz4",
+ "half",
+ "hashbrown 0.15.2",
+ "lz4_flex",
  "num",
  "num-bigint",
  "paste",
@@ -1857,27 +1893,8 @@ dependencies = [
  "snap",
  "thrift",
  "twox-hash",
- "zstd 0.12.4",
-]
-
-[[package]]
-name = "parquet"
-version = "50.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "547b92ebf0c1177e3892f44c8f79757ee62e678d564a9834189725f2c5b7a750"
-dependencies = [
- "ahash",
- "bytes",
- "chrono",
- "half",
- "hashbrown",
- "num",
- "num-bigint",
- "paste",
- "seq-macro",
- "thrift",
- "twox-hash",
- "zstd 0.13.2",
+ "zstd",
+ "zstd-sys",
 ]
 
 [[package]]
@@ -1909,7 +1926,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2178,9 +2195,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.31.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
 dependencies = [
  "bitflags 2.6.0",
  "fallible-iterator",
@@ -2268,7 +2285,7 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "sage-cli"
-version = "0.15.0-alpha"
+version = "0.16.0-beta.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2290,7 +2307,7 @@ dependencies = [
 
 [[package]]
 name = "sage-cloudpath"
-version = "0.15.0-alpha"
+version = "0.16.0-beta.1"
 dependencies = [
  "async-compression",
  "aws-config",
@@ -2316,7 +2333,7 @@ dependencies = [
 
 [[package]]
 name = "sage-core"
-version = "0.15.0-alpha"
+version = "0.16.0-beta.1"
 dependencies = [
  "dashmap",
  "fnv",
@@ -2391,29 +2408,29 @@ checksum = "a3f0bf26fd526d2a95683cd0f87bf103b8539e2ca1ef48ce002d67aad59aa0b4"
 
 [[package]]
 name = "serde"
-version = "1.0.209"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
+checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.209"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
+checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.127"
+version = "1.0.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8043c06d9f82bd7271361ed64f415fe5e12a77fdb52e573e7f06a516dea329ad"
+checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
 dependencies = [
  "itoa",
  "memchr",
@@ -2535,9 +2552,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.77"
+version = "2.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
+checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2612,7 +2629,7 @@ checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2658,20 +2675,20 @@ dependencies = [
 
 [[package]]
 name = "timsrust"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e6cc90c026b287bcea09d4a68231ee81dc3ec773447894134ad226fff006a20"
+checksum = "04312195f615fc45ea21087f564c4b3bfac2193690e0c0845b67f635f787f3c6"
 dependencies = [
  "bytemuck",
  "linreg",
  "memmap2",
- "parquet 42.0.0",
+ "parquet 53.4.0",
  "rayon",
  "rusqlite",
  "serde",
  "serde_json",
  "thiserror",
- "zstd 0.13.2",
+ "zstd",
 ]
 
 [[package]]
@@ -2722,7 +2739,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2818,7 +2835,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2978,7 +2995,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
  "wasm-bindgen-shared",
 ]
 
@@ -3012,7 +3029,7 @@ checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3276,7 +3293,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3287,30 +3304,11 @@ checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
 name = "zstd"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a27595e173641171fc74a1232b7b1c7a7cb6e18222c11e9dfb9888fa424c53c"
-dependencies = [
- "zstd-safe 6.0.6",
-]
-
-[[package]]
-name = "zstd"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
 dependencies = [
- "zstd-safe 7.2.1",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "6.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee98ffd0b48ee95e6c5168188e44a54550b1564d9d530ee21d5f0eaed1069581"
-dependencies = [
- "libc",
- "zstd-sys",
+ "zstd-safe",
 ]
 
 [[package]]

--- a/crates/sage-cli/Cargo.toml
+++ b/crates/sage-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sage-cli"
-version = "0.15.0-alpha"
+version = "0.16.0-beta.1"
 authors = ["Michael Lazear <michaellazear92@gmail.com"]
 edition = "2021"
 rust-version = "1.62"
@@ -36,3 +36,4 @@ ryu = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sysinfo = "0.29"
+

--- a/crates/sage-cli/src/input.rs
+++ b/crates/sage-cli/src/input.rs
@@ -92,7 +92,9 @@ impl From<LfqOptions> for LfqSettings {
             integration: value.integration.unwrap_or(default.integration),
             spectral_angle: value.spectral_angle.unwrap_or(default.spectral_angle).abs(),
             ppm_tolerance: value.ppm_tolerance.unwrap_or(default.ppm_tolerance).abs(),
-            mobility_pct_tolerance: value.mobility_pct_tolerance.unwrap_or(default.mobility_pct_tolerance),
+            mobility_pct_tolerance: value
+                .mobility_pct_tolerance
+                .unwrap_or(default.mobility_pct_tolerance),
             combine_charge_states: value
                 .combine_charge_states
                 .unwrap_or(default.combine_charge_states),

--- a/crates/sage-cli/src/input.rs
+++ b/crates/sage-cli/src/input.rs
@@ -1,6 +1,6 @@
 use anyhow::{ensure, Context};
 use clap::ArgMatches;
-use sage_cloudpath::{tdf::BrukerSpectrumProcessor, CloudPath};
+use sage_cloudpath::{tdf::BrukerProcessingConfig, CloudPath};
 use sage_core::scoring::ScoreType;
 use sage_core::{
     database::{Builder, Parameters},
@@ -32,7 +32,7 @@ pub struct Search {
     pub predict_rt: bool,
     pub mzml_paths: Vec<String>,
     pub output_paths: Vec<String>,
-    pub bruker_spectrum_processor: BrukerSpectrumProcessor,
+    pub bruker_config: BrukerProcessingConfig,
 
     #[serde(skip_serializing)]
     pub output_directory: CloudPath,
@@ -67,7 +67,7 @@ pub struct Input {
     pub predict_rt: Option<bool>,
     pub output_directory: Option<String>,
     pub mzml_paths: Option<Vec<String>>,
-    pub bruker_spectrum_processor: Option<BrukerSpectrumProcessor>,
+    pub bruker_config: Option<BrukerProcessingConfig>,
 
     pub annotate_matches: Option<bool>,
     pub write_pin: Option<bool>,
@@ -228,10 +228,15 @@ impl Input {
         sage_cloudpath::util::read_json(path).map_err(anyhow::Error::from)
     }
 
-    fn check_tolerances(tolerance: &Tolerance) {
+    fn check_mass_tolerances(tolerance: &Tolerance) {
         let (lo, hi) = match tolerance {
             Tolerance::Ppm(lo, hi) => (*lo, *hi),
-            Tolerance::Pct(_, _) => unreachable!("Pct tolerance should never be used on mz"),
+            Tolerance::Pct(lo, hi) => {
+                log::warn!(
+                    "Pct tolerances are very rarely used for mass tolerances, did you mean ppm?"
+                );
+                (*lo, *hi)
+            }
             Tolerance::Da(lo, hi) => (*lo, *hi),
         };
         if hi.abs() > lo.abs() {
@@ -260,8 +265,8 @@ impl Input {
     pub fn build(mut self) -> anyhow::Result<Search> {
         let database = self.database.make_parameters();
 
-        Self::check_tolerances(&self.fragment_tol);
-        Self::check_tolerances(&self.precursor_tol);
+        Self::check_mass_tolerances(&self.fragment_tol);
+        Self::check_mass_tolerances(&self.precursor_tol);
 
         if let Some(isotope_errors) = self.isotope_errors {
             if isotope_errors.0 > isotope_errors.1 {
@@ -327,7 +332,7 @@ impl Input {
             predict_rt: self.predict_rt.unwrap_or(true),
             output_paths: Vec::new(),
             write_pin: self.write_pin.unwrap_or(false),
-            bruker_spectrum_processor: self.bruker_spectrum_processor.unwrap_or_default(),
+            bruker_config: self.bruker_config.unwrap_or_default(),
             score_type,
         })
     }

--- a/crates/sage-cli/src/output.rs
+++ b/crates/sage-cli/src/output.rs
@@ -40,7 +40,11 @@ impl FromParallelIterator<SageResults> for SageResults {
                         acc.ms1 = MS1Spectra::NoMobility(a);
                     }
                     _ => {
-                        unreachable!()
+                        // In theory this can happen if someone is searching
+                        // together files of different types, mixing the ones
+                        // that support IMS and the ones that dont.
+                        // ... I dont think this should be run-time recoverable.
+                        unreachable!("Found combination of MS1 spectra with and without mobility.")
                     }
                 };
                 acc
@@ -79,7 +83,7 @@ impl FromIterator<SageResults> for SageResults {
                         acc.ms1 = MS1Spectra::NoMobility(a);
                     }
                     _ => {
-                        unreachable!()
+                        unreachable!("Found combination of MS1 spectra with and without mobility.")
                     }
                 };
                 acc

--- a/crates/sage-cli/src/output.rs
+++ b/crates/sage-cli/src/output.rs
@@ -1,5 +1,5 @@
 use rayon::prelude::*;
-use sage_core::spectrum::{MS1Spectra, ProcessedSpectrum};
+use sage_core::spectrum::MS1Spectra;
 use sage_core::{scoring::Feature, tmt::TmtQuant};
 
 #[derive(Default)]

--- a/crates/sage-cli/src/output.rs
+++ b/crates/sage-cli/src/output.rs
@@ -1,7 +1,6 @@
 use rayon::prelude::*;
-use sage_core::spectrum::{ProcessedSpectrum, MS1Spectra};
+use sage_core::spectrum::{MS1Spectra, ProcessedSpectrum};
 use sage_core::{scoring::Feature, tmt::TmtQuant};
-
 
 #[derive(Default)]
 pub struct SageResults {
@@ -32,13 +31,17 @@ impl FromParallelIterator<SageResults> for SageResults {
                     (MS1Spectra::Empty, MS1Spectra::Empty) => {
                         acc.ms1 = MS1Spectra::Empty;
                     }
-                    (MS1Spectra::Empty, MS1Spectra::WithMobility(a)) | (MS1Spectra::WithMobility(a), MS1Spectra::Empty) => {
+                    (MS1Spectra::Empty, MS1Spectra::WithMobility(a))
+                    | (MS1Spectra::WithMobility(a), MS1Spectra::Empty) => {
                         acc.ms1 = MS1Spectra::WithMobility(a);
                     }
-                    (MS1Spectra::Empty, MS1Spectra::NoMobility(a)) | (MS1Spectra::NoMobility(a), MS1Spectra::Empty) => {
+                    (MS1Spectra::Empty, MS1Spectra::NoMobility(a))
+                    | (MS1Spectra::NoMobility(a), MS1Spectra::Empty) => {
                         acc.ms1 = MS1Spectra::NoMobility(a);
                     }
-                    _ => {unreachable!()}
+                    _ => {
+                        unreachable!()
+                    }
                 };
                 acc
             })
@@ -67,13 +70,17 @@ impl FromIterator<SageResults> for SageResults {
                     (MS1Spectra::Empty, MS1Spectra::Empty) => {
                         acc.ms1 = MS1Spectra::Empty;
                     }
-                    (MS1Spectra::Empty, MS1Spectra::WithMobility(a)) | (MS1Spectra::WithMobility(a), MS1Spectra::Empty) => {
+                    (MS1Spectra::Empty, MS1Spectra::WithMobility(a))
+                    | (MS1Spectra::WithMobility(a), MS1Spectra::Empty) => {
                         acc.ms1 = MS1Spectra::WithMobility(a);
                     }
-                    (MS1Spectra::Empty, MS1Spectra::NoMobility(a)) | (MS1Spectra::NoMobility(a), MS1Spectra::Empty) => {
+                    (MS1Spectra::Empty, MS1Spectra::NoMobility(a))
+                    | (MS1Spectra::NoMobility(a), MS1Spectra::Empty) => {
                         acc.ms1 = MS1Spectra::NoMobility(a);
                     }
-                    _ => {unreachable!()}
+                    _ => {
+                        unreachable!()
+                    }
                 };
                 acc
             })

--- a/crates/sage-cli/src/runner.rs
+++ b/crates/sage-cli/src/runner.rs
@@ -106,10 +106,10 @@ impl Runner {
         };
 
         info!(
-            "generated {} fragments, {} peptides in {}ms",
+            "generated {} fragments, {} peptides in {:#?}",
             database.fragments.len(),
             database.peptides.len(),
-            (Instant::now() - start).as_millis()
+            (start.elapsed())
         );
         Ok(Self {
             database,

--- a/crates/sage-cli/src/runner.rs
+++ b/crates/sage-cli/src/runner.rs
@@ -14,7 +14,7 @@ use sage_core::mass::Tolerance;
 use sage_core::peptide::Peptide;
 use sage_core::scoring::Fragments;
 use sage_core::scoring::{Feature, Scorer};
-use sage_core::spectrum::{ProcessedSpectrum, SpectrumProcessor};
+use sage_core::spectrum::{MS1Spectra, ProcessedSpectrum, RawSpectrum, SpectrumProcessor};
 use sage_core::tmt::TmtQuant;
 use std::collections::HashMap;
 use std::collections::HashSet;
@@ -24,6 +24,43 @@ pub struct Runner {
     pub database: IndexedDatabase, // I could use a getter if I dont want to make this pub ...
     pub parameters: Search,
     start: Instant,
+}
+
+#[derive(Default)]
+struct RawSpectrumAccumulator {
+    pub ms1: Vec<RawSpectrum>,
+    pub msn: Vec<RawSpectrum>,
+}
+
+impl FromParallelIterator<RawSpectrum> for RawSpectrumAccumulator {
+    fn from_par_iter<I>(par_iter: I) -> Self
+    where
+        I: IntoParallelIterator<Item = RawSpectrum>,
+    {
+        let out = par_iter
+            .into_par_iter()
+            .fold(
+                || RawSpectrumAccumulator::default(),
+                |mut accum, spectrum| {
+                    if spectrum.ms_level == 1 {
+                        accum.ms1.push(spectrum);
+                    } else {
+                        accum.msn.push(spectrum);
+                    }
+                    accum
+                },
+            )
+            .reduce(
+                || RawSpectrumAccumulator::default(),
+                |mut a, b| {
+                    a.ms1.extend(b.ms1);
+                    a.msn.extend(b.msn);
+                    a
+                },
+            );
+
+        out
+    }
 }
 
 impl Runner {
@@ -82,11 +119,13 @@ impl Runner {
     }
 
     pub fn prefilter_peptides(self, parallel: usize, fasta: Fasta) -> Vec<Peptide> {
-        let spectra: Option<Vec<ProcessedSpectrum>> =
-            match parallel >= self.parameters.mzml_paths.len() {
-                true => Some(self.read_processed_spectra(&self.parameters.mzml_paths, 0, 0)),
-                false => None,
-            };
+        let spectra: Option<(
+            MS1Spectra,
+            Vec<ProcessedSpectrum<sage_core::spectrum::Peak>>,
+        )> = match parallel >= self.parameters.mzml_paths.len() {
+            true => Some(self.read_processed_spectra(&self.parameters.mzml_paths, 0, 0)),
+            false => None,
+        };
         let mut all_peptides: Vec<Peptide> = fasta
             .iter_chunks(self.parameters.database.prefilter_chunk_size)
             .enumerate()
@@ -112,13 +151,13 @@ impl Runner {
                     override_precursor_charge: self.parameters.override_precursor_charge,
                     max_fragment_charge: self.parameters.max_fragment_charge,
                     chimera: self.parameters.chimera,
-                    report_psms: self.parameters.report_psms + 1,
+                    report_psms: self.parameters.report_psms + 1, // Q: Why is 1 being added here? (JSPP: Feb 2024)
                     wide_window: self.parameters.wide_window,
                     annotate_matches: self.parameters.annotate_matches,
                     score_type: self.parameters.score_type,
                 };
                 let peptide_idxs: HashSet<PeptideIx> = match &spectra {
-                    Some(spectra) => self.peptide_filter_processed_spectra(&scorer, spectra),
+                    Some(spectra) => self.peptide_filter_processed_spectra(&scorer, &spectra.1),
                     None => self
                         .parameters
                         .mzml_paths
@@ -127,7 +166,7 @@ impl Runner {
                         .flat_map(|(chunk_idx, chunk)| {
                             let spectra_chunk =
                                 self.read_processed_spectra(chunk, chunk_idx, parallel);
-                            self.peptide_filter_processed_spectra(&scorer, &spectra_chunk)
+                            self.peptide_filter_processed_spectra(&scorer, &spectra_chunk.1)
                         })
                         .collect(),
                 }
@@ -152,7 +191,7 @@ impl Runner {
     fn peptide_filter_processed_spectra(
         &self,
         scorer: &Scorer,
-        spectra: &Vec<ProcessedSpectrum>,
+        spectra: &Vec<ProcessedSpectrum<sage_core::spectrum::Peak>>,
     ) -> Vec<PeptideIx> {
         use std::sync::atomic::{AtomicUsize, Ordering};
         let counter = AtomicUsize::new(0);
@@ -207,13 +246,13 @@ impl Runner {
     fn search_processed_spectra(
         &self,
         scorer: &Scorer,
-        spectra: &Vec<ProcessedSpectrum>,
+        msn_spectra: &Vec<ProcessedSpectrum<sage_core::spectrum::Peak>>,
     ) -> Vec<Feature> {
         use std::sync::atomic::{AtomicUsize, Ordering};
         let counter = AtomicUsize::new(0);
         let start = Instant::now();
 
-        let features: Vec<_> = spectra
+        let features: Vec<_> = msn_spectra
             .par_iter()
             .filter(|spec| spec.peaks.len() >= self.parameters.min_peaks && spec.level == 2)
             .map(|x| {
@@ -238,7 +277,8 @@ impl Runner {
 
     fn complete_features(
         &self,
-        spectra: Vec<ProcessedSpectrum>,
+        msn_spectra: Vec<ProcessedSpectrum<sage_core::spectrum::Peak>>,
+        ms1_spectra: MS1Spectra,
         features: Vec<Feature>,
     ) -> SageResults {
         let quant = self
@@ -251,16 +291,19 @@ impl Runner {
                 if level != 2 && level != 3 {
                     log::warn!("TMT quant level set at {}, is this correct?", level);
                 }
-                sage_core::tmt::quantify(&spectra, isobaric, Tolerance::Ppm(-20.0, 20.0), level)
+                sage_core::tmt::quantify(&msn_spectra, isobaric, Tolerance::Ppm(-20.0, 20.0), level)
             })
             .unwrap_or_default();
-        let ms1 = spectra.into_iter().filter(|s| s.level == 1).collect();
 
         SageResults {
             features,
             quant,
-            ms1,
+            ms1: ms1_spectra,
         }
+    }
+
+    fn requires_ms1(&self) -> bool {
+        self.parameters.quant.lfq
     }
 
     fn process_chunk(
@@ -271,8 +314,8 @@ impl Runner {
         batch_size: usize,
     ) -> SageResults {
         let spectra = self.read_processed_spectra(chunk, chunk_idx, batch_size);
-        let features = self.search_processed_spectra(scorer, &spectra);
-        self.complete_features(spectra, features)
+        let features = self.search_processed_spectra(scorer, &spectra.1);
+        self.complete_features(spectra.1, spectra.0, features)
     }
 
     fn read_processed_spectra(
@@ -280,7 +323,10 @@ impl Runner {
         chunk: &[String],
         chunk_idx: usize,
         batch_size: usize,
-    ) -> Vec<ProcessedSpectrum> {
+    ) -> (
+        MS1Spectra,
+        Vec<ProcessedSpectrum<sage_core::spectrum::Peak>>,
+    ) {
         // Read all of the spectra at once - this can help prevent memory over-consumption issues
         info!(
             "processing files {} .. {} ",
@@ -310,7 +356,7 @@ impl Runner {
             min_deisotope_mz.unwrap_or(0.0),
         );
 
-        let spectra = chunk
+        let spectra: RawSpectrumAccumulator = chunk
             .par_iter()
             .enumerate()
             .flat_map(|(idx, path)| {
@@ -320,6 +366,7 @@ impl Runner {
                     file_id,
                     sn,
                     self.parameters.bruker_spectrum_processor,
+                    self.requires_ms1(),
                 );
 
                 match res {
@@ -333,13 +380,36 @@ impl Runner {
                     }
                 }
             })
-            .flat_map_iter(|spectra| spectra.into_iter().map(|s| sp.process(s)))
+            .flatten()
+            .collect();
+
+        let msn_spectra = spectra
+            .msn
+            .into_par_iter()
+            .map(|s| sp.process(s))
             .collect::<Vec<_>>();
+
+        // Note: Empty iterators return true.
+        let all_contain_ims = spectra.ms1.iter().all(|x| x.mobility.is_some());
+        let ms1_empty = spectra.ms1.is_empty();
+        let ms1_spectra = if ms1_empty {
+            MS1Spectra::Empty
+        } else if all_contain_ims {
+            let spectra = spectra
+                .ms1
+                .into_iter()
+                .map(|x| sp.process_with_mobility(x))
+                .collect();
+            MS1Spectra::WithMobility(spectra)
+        } else {
+            let spectra = spectra.ms1.into_iter().map(|s| sp.process(s)).collect();
+            MS1Spectra::NoMobility(spectra)
+        };
 
         let io_time = Instant::now() - start;
         info!("- file IO: {:8} ms", io_time.as_millis());
 
-        spectra
+        (ms1_spectra, msn_spectra)
     }
 
     pub fn batch_files(&self, scorer: &Scorer, batch_size: usize) -> SageResults {

--- a/crates/sage-cli/src/runner.rs
+++ b/crates/sage-cli/src/runner.rs
@@ -385,7 +385,7 @@ impl Runner {
                 path,
                 file_id,
                 sn,
-                self.parameters.bruker_spectrum_processor,
+                self.parameters.bruker_config.clone(),
                 self.requires_ms1(),
             );
 

--- a/crates/sage-cloudpath/Cargo.toml
+++ b/crates/sage-cloudpath/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sage-cloudpath"
-version = "0.15.0-alpha"
+version = "0.16.0-beta.1"
 authors = ["Michael Lazear <michaellazear92@gmail.com"]
 edition = "2021"
 rust-version = "1.62"

--- a/crates/sage-cloudpath/Cargo.toml
+++ b/crates/sage-cloudpath/Cargo.toml
@@ -23,7 +23,7 @@ log = "0.4.0"
 once_cell = "1.0"
 tokio = { version = "1.0", features = ["fs", "io-util", "rt", "macros"] }
 quick-xml = { version = "0.31.0", features = ["async-tokio"] }
-timsrust = { version = "0.4.1"}
+timsrust = { version = "0.4.2"}
 rayon = "1.5"
 reqwest = { version = "0.11", features = ["json", "rustls-tls"], default-features = false }
 regex = "1.6"

--- a/crates/sage-cloudpath/src/lib.rs
+++ b/crates/sage-cloudpath/src/lib.rs
@@ -10,6 +10,7 @@ pub mod mgf;
 pub mod mzml;
 pub mod tdf;
 pub mod util;
+pub use util::FileFormat;
 
 #[cfg(feature = "parquet")]
 pub mod parquet;

--- a/crates/sage-cloudpath/src/tdf.rs
+++ b/crates/sage-cloudpath/src/tdf.rs
@@ -12,8 +12,8 @@ pub struct TdfReader;
 
 #[derive(Deserialize, Serialize, Debug, Clone, Copy)]
 pub struct BrukerMS1CentoidingConfig {
-    mz_ppm: f32,
-    ims_pct: f32,
+    pub mz_ppm: f32,
+    pub ims_pct: f32,
 }
 
 impl Default for BrukerMS1CentoidingConfig {
@@ -27,8 +27,8 @@ impl Default for BrukerMS1CentoidingConfig {
 
 #[derive(Default, Deserialize, Serialize, Debug, Clone, Copy)]
 pub struct BrukerProcessingConfig {
-    ms2: TimsrustSpectrumConfig,
-    ms1: BrukerMS1CentoidingConfig,
+    pub ms2: TimsrustSpectrumConfig,
+    pub ms1: BrukerMS1CentoidingConfig,
 }
 
 impl TdfReader {

--- a/crates/sage-cloudpath/src/tdf.rs
+++ b/crates/sage-cloudpath/src/tdf.rs
@@ -249,10 +249,6 @@ fn dumbcentroid_frame(
 
     for &idx in &order {
         if intensity_array[idx] <= 0.0 {
-            // In theory ... if I set the intensity as mutable
-            // I could remove the use of the 'included' vector
-            // and just set to -1.0 the intensity of the peaks
-            // I have already included.
             continue;
         }
         if agg_buff.len() > MAX_PEAKS {

--- a/crates/sage-cloudpath/src/tdf.rs
+++ b/crates/sage-cloudpath/src/tdf.rs
@@ -5,7 +5,7 @@ use sage_core::{
 };
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
-use timsrust::converters::{ConvertableDomain, Scan2ImConverter};
+use timsrust::converters::{ConvertableDomain, Scan2ImConverter, Tof2MzConverter};
 use timsrust::readers::SpectrumReader;
 use timsrust::readers::SpectrumReaderConfig as TimsrustSpectrumConfig;
 pub struct TdfReader;
@@ -69,70 +69,45 @@ impl TdfReader {
 
         let ms1_spectra: Vec<RawSpectrum> = frame_reader
             .parallel_filter(|f| f.ms_level == timsrust::MSLevel::MS1)
-            .filter_map(|frame| match frame {
-                Ok(frame) => {
-                    let mz: Vec<f32> = frame
-                        .tof_indices
-                        .iter()
-                        .map(|&x| mz_converter.convert(x as f64) as f32)
-                        .collect();
-                    let corr_factor = frame.intensity_correction_factor as f32;
-                    let intensity: Vec<f32> = frame
-                        .intensities
-                        .iter()
-                        .map(|&x| x as f32 * corr_factor)
-                        .collect();
-                    let imss = Self::expand_mobility(&frame.scan_offsets, &ims_converter);
-                    assert_eq!(mz.len(), intensity.len(), "{:?}", frame);
-                    assert_eq!(mz.len(), imss.len(), "{:?}", frame);
+            .map_init(
+                || PeakBuffer::with_capacity(2 * MAX_PEAKS),
+                |buffer, frame| match frame {
+                    Ok(frame) => {
+                        buffer.clear();
+                        buffer.with_frame(&frame, &ims_converter, &mz_converter);
 
-                    // Sort the mzs, imss and intensities by mz
-                    let mut indices: Vec<usize> = (0..mz.len()).collect();
-                    indices.sort_by(|&i, &j| {
-                        mz[i]
-                            .partial_cmp(&mz[j])
-                            .unwrap_or(std::cmp::Ordering::Equal)
-                    });
-                    let sorted_mz: Vec<f32> = indices.iter().map(|&i| mz[i]).collect();
-                    let sorted_inten: Vec<f32> = indices.iter().map(|&i| intensity[i]).collect();
-                    let sorted_imss: Vec<f32> = indices.iter().map(|&i| imss[i]).collect();
+                        // Squash the mobility dimension
+                        let (mz, (intensity, mobility)): (Vec<f32>, (Vec<f32>, Vec<f32>)) =
+                            buffer.fastcentroid_frame(tol_ppm, im_tol_pct);
 
-                    // Squash the mobility dimension
-                    let (mz, (intensity, mobility)): (Vec<f32>, (Vec<f32>, Vec<f32>)) =
-                        dumbcentroid_frame(
-                            sorted_mz,
-                            sorted_inten,
-                            sorted_imss,
-                            tol_ppm,
-                            im_tol_pct,
-                        );
+                        let scan_start_time = frame.rt_in_seconds as f32 / 60.0;
+                        let ion_injection_time = 100.0; // This is made up, in theory we can read
+                                                        // if from the tdf file
+                        let total_ion_current = intensity.iter().sum::<f32>();
+                        let id = frame.index.to_string();
 
-                    let scan_start_time = frame.rt_in_seconds as f32 / 60.0;
-                    let ion_injection_time = 100.0; // This is made up, in theory we can read
-                                                    // if from the tdf file
-                    let total_ion_current = intensity.iter().sum::<f32>();
-                    let id = frame.index.to_string();
-
-                    let spec = RawSpectrum {
-                        file_id,
-                        precursors: vec![],
-                        representation: Representation::Centroid,
-                        scan_start_time,
-                        ion_injection_time,
-                        mz,
-                        ms_level: 1,
-                        id,
-                        intensity,
-                        total_ion_current,
-                        mobility: Some(mobility),
-                    };
-                    Some(spec)
-                }
-                Err(x) => {
-                    log::error!("error parsing spectrum: {:?}", x);
-                    None
-                }
-            })
+                        let spec = RawSpectrum {
+                            file_id,
+                            precursors: vec![],
+                            representation: Representation::Centroid,
+                            scan_start_time,
+                            ion_injection_time,
+                            mz,
+                            ms_level: 1,
+                            id,
+                            intensity,
+                            total_ion_current,
+                            mobility: Some(mobility),
+                        };
+                        Some(spec)
+                    }
+                    Err(x) => {
+                        log::error!("error parsing spectrum: {:?}", x);
+                        None
+                    }
+                },
+            )
+            .flatten()
             .collect();
         log::info!(
             "read {} ms1 spectra in {:#?}",
@@ -189,18 +164,117 @@ impl TdfReader {
         precursor.inverse_ion_mobility = Option::from(dda_precursor.im as f32);
         precursor
     }
+}
 
-    fn expand_mobility(scan_offsets: &[usize], ims_converter: &Scan2ImConverter) -> Vec<f32> {
-        let capacity = match scan_offsets.last() {
-            Some(&x) => x,
-            None => return vec![],
-        };
-        let mut imss: Vec<f32> = vec![0.0; capacity];
-        // TODO: This is getting pretty big ... I should refactor this block.
-        scan_offsets
+#[derive(Clone, Copy)]
+struct ImsPeak {
+    mz: f32,
+    intensity: f32,
+    im: f32,
+}
+const MAX_PEAKS: usize = 10_000;
+
+/// Buffer that gets re-used on each thread to store the intermediates
+/// of the centroiding for a single frame.
+#[derive(Clone)]
+struct PeakBuffer {
+    peaks: Vec<ImsPeak>,
+    order: Vec<usize>,
+    agg_buff: Vec<ImsPeak>,
+}
+
+impl PeakBuffer {
+    fn with_capacity(capacity: usize) -> Self {
+        Self {
+            peaks: Vec::with_capacity(capacity),
+            order: Vec::with_capacity(capacity),
+            agg_buff: Vec::with_capacity(MAX_PEAKS),
+        }
+    }
+
+    fn with_frame(
+        &mut self,
+        frame: &timsrust::Frame,
+        ims_converter: &Scan2ImConverter,
+        mz_converter: &Tof2MzConverter,
+    ) {
+        let expect_len = frame.tof_indices.len();
+        self.expand_to_capacity(expect_len);
+
+        let mz_iter = frame
+            .tof_indices
+            .iter()
+            .map(|&x| mz_converter.convert(x as f64) as f32);
+        let intensities_iter = frame.intensities.iter().map(|&x| x as f32);
+        let imss_iter = Self::expand_mobility_iter(&frame.scan_offsets, ims_converter);
+
+        let peak_iter = mz_iter
+            .zip(intensities_iter)
+            .zip(imss_iter)
+            .map(|((mz, intensity), im)| ImsPeak { mz, intensity, im });
+        self.peaks.extend(peak_iter);
+        assert_eq!(self.peaks.len(), expect_len);
+
+        // sort by mz ... bc binary searching on the mz space
+        // for neighbors is the fastest way to find neighbors that I have tried.
+        self.peaks.sort_by(|a, b| a.mz.partial_cmp(&b.mz).unwrap());
+
+        // The "order" is sorted by intensity
+        // This will be used later during the centroiding (for details check that implementation)
+        self.order.extend((0..self.len()));
+        self.order.sort_unstable_by(|&a, &b| {
+            self.peaks[b]
+                .intensity
+                .partial_cmp(&self.peaks[a].intensity)
+                .unwrap_or(Ordering::Equal)
+        });
+    }
+
+    fn clear(&mut self) {
+        self.peaks.clear();
+        self.order.clear();
+        self.agg_buff.clear();
+    }
+
+    fn expand_to_capacity(&mut self, capacity: usize) {
+        if capacity <= self.len() {
+            return;
+        }
+        let diff = capacity - self.len();
+        // Grow by whatever is the largest 20% of the current capacity
+        // or the difference.
+        let diff = diff.max(self.len() / 5);
+
+        self.peaks.reserve(diff);
+        self.order.reserve(diff);
+        self.agg_buff.reserve(capacity);
+    }
+
+    fn len(&self) -> usize {
+        self.peaks.len()
+    }
+
+    /// Expand the scan offset slice to mobilities.
+    ///
+    /// The scan offsets is in essence a run-length
+    /// encoded vector of scan numbers that can be converter to the 1/k0
+    /// values.
+    ///
+    /// Essentially ... the slice [0,4,5,5], would expand to
+    /// [0,0,0,0,1]; 0 to 4 have index 0, 4 to 5 have index 1, 5 to 5 would
+    /// have index 2 but its empty!
+    ///
+    /// Then this index can be converted using the Scan2ImConverter.convert
+    ///
+    /// ... This should problably be implemented and exposed in timsrust.
+    fn expand_mobility_iter<'a>(
+        scan_offsets: &'a [usize],
+        ims_converter: &'a Scan2ImConverter,
+    ) -> impl Iterator<Item = f32> + 'a {
+        let ims_iter = scan_offsets
             .windows(2)
             .enumerate()
-            .map(|(i, w)| {
+            .filter_map(|(i, w)| {
                 let num = w[1] - w[0];
                 if num == 0 {
                     return None;
@@ -211,129 +285,116 @@ impl TdfReader {
                 let im = ims_converter.convert(i as f64) as f32;
                 Some((im, lo, hi))
             })
-            .for_each(|x| {
-                if let Some((im, lo, hi)) = x {
-                    for i in lo..hi {
-                        imss[i] = im;
-                    }
+            .map(|(im, lo, hi)| (lo..hi).map(move |_| im))
+            .flatten();
+        ims_iter
+    }
+
+    /// Centroiding of the IM-containing spectra
+    ///
+    /// This is a very rudimentary centroiding algorithm but... it seems to work well.
+    /// It iterativelty goes over the peaks in decreasing intensity order and
+    /// accumulates the intensity of the peaks surrounding the peak. (sort of
+    /// like the first pass in dbscan).
+    ///
+    /// The preserved mobility and mz are the ones from the apex peak.
+    /// A more complex version where the weighted mean is preserved is possible
+    /// but I have seen only marginal gains and a lot more complexity + time.
+    ///
+    /// This dramatically reduces the number of peaks in the spectra
+    /// which saves a ton of memory and time when doing LFQ, since we
+    /// iterate over each peak.
+    fn fastcentroid_frame(
+        &mut self,
+        mz_tol_ppm: f32,
+        im_tol_pct: f32,
+    ) -> (Vec<f32>, (Vec<f32>, Vec<f32>)) {
+        // Make sure the array is mz sorted ... I should delete
+        // this assertions once I am confident of the implementation.
+        // but tbh, its not that slow and its simple.
+        assert!(
+            self.peaks.windows(2).all(|x| x[0].mz <= x[1].mz),
+            "mz_array is not sorted"
+        );
+        assert!(self.agg_buff.is_empty(), "agg_buff is not empty");
+
+        let mut global_num_included = 0;
+
+        let utol = mz_tol_ppm / 1e6;
+        let im_tol = im_tol_pct / 100.0;
+
+        for &idx in &self.order {
+            if self.peaks[idx].intensity <= 0.0 {
+                continue;
+            }
+            if self.agg_buff.len() > MAX_PEAKS {
+                let curr_loc_int = self.peaks[idx].intensity;
+                if curr_loc_int > 200.0 {
+                    log::debug!(
+                        "Reached limit of the agg buffer at index {}/{} curr int={}",
+                        idx,
+                        self.len(),
+                        curr_loc_int
+                    );
                 }
+                break;
+            }
+
+            let mz = self.peaks[idx].mz;
+            let im = self.peaks[idx].im;
+            let da_tol = mz * utol;
+            let left_e = mz - da_tol;
+            let right_e = mz + da_tol;
+
+            let ss_start = self.peaks.partition_point(|&x| x.mz < left_e);
+            let ss_end = self.peaks.partition_point(|&x| x.mz <= right_e);
+
+            let abs_im_tol = im * im_tol;
+            let left_im = im - abs_im_tol;
+            let right_im = im + abs_im_tol;
+
+            let mut curr_intensity = 0.0;
+
+            let mut num_includable = 0;
+            for i in ss_start..ss_end {
+                let im_i = self.peaks[i].im;
+                if (self.peaks[i].intensity > 0.0) && im_i >= left_im && im_i <= right_im {
+                    curr_intensity += self.peaks[i].intensity;
+                    self.peaks[i].intensity = -1.0;
+                    num_includable += 1;
+                }
+            }
+
+            assert!(num_includable > 0, "At least 'itself' should be included");
+
+            self.agg_buff.push(ImsPeak {
+                mz,
+                intensity: curr_intensity,
+                im,
             });
-        imss
-    }
-}
+            global_num_included += num_includable;
 
-/// Centroiding of the IM-containing spectra
-///
-/// This is a very rudimentary centroiding algorithm but... it seems to work well.
-/// It iterativelty goes over the peaks in decreasing intensity order and
-/// accumulates the intensity of the peaks surrounding the peak. (sort of
-/// like the first pass in dbscan).
-///
-/// This dramatically reduces the number of peaks in the spectra
-/// which saves a ton of memory and time when doing LFQ, since we
-/// iterate over each peak.
-fn dumbcentroid_frame(
-    mz_array: Vec<f32>,
-    mut intensity_array: Vec<f32>,
-    ims_array: Vec<f32>,
-    mz_tol_ppm: f32,
-    im_tol_pct: f32,
-) -> (Vec<f32>, (Vec<f32>, Vec<f32>)) {
-    // Make sure the mz array is sorted
-    // In theory I could use the type system to enforce this but I dont
-    // think it is worth it, its not that slow and its simple.
-    assert!(
-        mz_array.windows(2).all(|x| x[0] <= x[1]),
-        "mz_array is not sorted"
-    );
-
-    let arr_len = mz_array.len();
-    let mut global_num_included = 0;
-
-    let mut order: Vec<usize> = (0..arr_len).collect();
-    order.sort_unstable_by(|&a, &b| {
-        intensity_array[b]
-            .partial_cmp(&intensity_array[a])
-            .unwrap_or(Ordering::Equal)
-    });
-
-    #[derive(Clone, Copy)]
-    struct ImsPeak {
-        mz: f32,
-        intensity: f32,
-        im: f32,
-    }
-    const MAX_PEAKS: usize = 10_000;
-    let mut agg_buff = Vec::with_capacity(MAX_PEAKS.min(arr_len));
-
-    let utol = mz_tol_ppm / 1e6;
-    let im_tol = im_tol_pct / 100.0;
-
-    for &idx in &order {
-        if intensity_array[idx] <= 0.0 {
-            continue;
-        }
-        if agg_buff.len() > MAX_PEAKS {
-            let curr_loc_int = intensity_array[idx];
-            if curr_loc_int > 200.0 {
-                log::debug!(
-                    "Reached limit of the agg buffer at index {}/{} curr int={}",
-                    idx,
-                    arr_len,
-                    curr_loc_int
-                );
-            }
-            break;
-        }
-
-        let mz = mz_array[idx];
-        let im = ims_array[idx];
-        let da_tol = mz * utol;
-        let left_e = mz - da_tol;
-        let right_e = mz + da_tol;
-
-        let ss_start = mz_array.partition_point(|&x| x < left_e);
-        let ss_end = mz_array.partition_point(|&x| x <= right_e);
-
-        let abs_im_tol = im * im_tol;
-        let left_im = im - abs_im_tol;
-        let right_im = im + abs_im_tol;
-
-        let mut curr_intensity = 0.0;
-
-        let mut num_includable = 0;
-        for i in ss_start..ss_end {
-            let im_i = ims_array[i];
-            if (intensity_array[i] > 0.0) && im_i >= left_im && im_i <= right_im {
-                curr_intensity += intensity_array[i];
-                intensity_array[i] = -1.0;
-                num_includable += 1;
+            if global_num_included == self.len() {
+                log::debug!("All peaks were included in the centroiding");
+                break;
             }
         }
 
-        assert!(num_includable > 0, "At least 'itself' should be included");
+        self
+            .agg_buff
+            .sort_unstable_by(|a, b| a.mz.partial_cmp(&b.mz).unwrap());
+        // println!("Centroiding: Start len: {}; end len: {};", arr_len, result.len());
+        // Ultra data is usually start: 40k end 10k,
+        // HT2 data is usually start 400k end 40k, limiting to 10k
+        // rarely leaves peaks with intensity > 200 ... ive never seen
+        // it happen. -JSP 2025-Jan
 
-        agg_buff.push(ImsPeak {
-            mz,
-            intensity: curr_intensity,
-            im,
-        });
-        global_num_included += num_includable;
-
-        if global_num_included == arr_len {
-            break;
-        }
+        self
+            .agg_buff
+            .drain(..)
+            .into_iter()
+            .map(|x| (x.mz, (x.intensity, x.im)))
+            .unzip()
     }
-
-    agg_buff.sort_unstable_by(|a, b| a.mz.partial_cmp(&b.mz).unwrap());
-    // println!("Centroiding: Start len: {}; end len: {};", arr_len, result.len());
-    // Ultra data is usually start: 40k end 10k,
-    // HT2 data is usually start 400k end 40k, limiting to 10k
-    // rarely leaves peaks with intensity > 200 ... ive never seen
-    // it happen. -JSP 2025-Jan
-
-    agg_buff
-        .into_iter()
-        .map(|x| (x.mz, (x.intensity, x.im)))
-        .unzip()
 }
+

--- a/crates/sage-cloudpath/src/tdf.rs
+++ b/crates/sage-cloudpath/src/tdf.rs
@@ -86,10 +86,10 @@ impl TdfReader {
                             .partial_cmp(&mz[j])
                             .unwrap_or(std::cmp::Ordering::Equal)
                     });
-                    let sorted_mz: Vec<f32> = indices.iter().map(|&i| mz[i].clone()).collect();
+                    let sorted_mz: Vec<f32> = indices.iter().map(|&i| mz[i]).collect();
                     let sorted_inten: Vec<f32> =
-                        indices.iter().map(|&i| intensity[i].clone()).collect();
-                    let sorted_imss: Vec<f32> = indices.iter().map(|&i| imss[i].clone()).collect();
+                        indices.iter().map(|&i| intensity[i]).collect();
+                    let sorted_imss: Vec<f32> = indices.iter().map(|&i| imss[i]).collect();
 
                     // Squash the mobility dimension
                     let tol_ppm = 15.0;
@@ -179,14 +179,8 @@ impl TdfReader {
     fn parse_precursor(dda_precursor: timsrust::Precursor) -> Precursor {
         let mut precursor: Precursor = Precursor::default();
         precursor.mz = dda_precursor.mz as f32;
-        precursor.charge = match dda_precursor.charge {
-            Some(x) => Some(x as u8),
-            None => None,
-        };
-        precursor.intensity = match dda_precursor.intensity {
-            Some(x) => Some(x as f32),
-            None => None,
-        };
+        precursor.charge = dda_precursor.charge.map(|x| x as u8);
+        precursor.intensity = dda_precursor.intensity.map(|x| x as f32);
         precursor.spectrum_ref = Option::from(dda_precursor.frame_index.to_string());
         precursor.inverse_ion_mobility = Option::from(dda_precursor.im as f32);
         precursor
@@ -323,7 +317,7 @@ fn dumbcentroid_frame(
     let mut result: Vec<(f32, (f32, f32))> = agg_buff
         .iter()
         .filter(|&x| x.mz > 0.0 && x.intensity > 0.0)
-        .map(|x| (x.mz, (x.intensity, x.im as f32)))
+        .map(|x| (x.mz, (x.intensity, x.im)))
         .collect();
 
     result.sort_unstable_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(Ordering::Equal));

--- a/crates/sage-cloudpath/src/tdf.rs
+++ b/crates/sage-cloudpath/src/tdf.rs
@@ -3,7 +3,10 @@ use sage_core::{
     mass::Tolerance,
     spectrum::{Precursor, RawSpectrum, Representation},
 };
+use timsrust::readers::SpectrumReader;
+use timsrust::converters::ConvertableDomain;
 pub use timsrust::readers::SpectrumReaderConfig as BrukerSpectrumProcessor;
+use std::cmp::Ordering;
 
 pub struct TdfReader;
 
@@ -13,11 +16,107 @@ impl TdfReader {
         path_name: impl AsRef<str>,
         file_id: usize,
         bruker_spectrum_processor: BrukerSpectrumProcessor,
+        requires_ms1: bool,
     ) -> Result<Vec<RawSpectrum>, timsrust::TimsRustError> {
         let spectrum_reader = timsrust::readers::SpectrumReader::build()
             .with_path(path_name.as_ref())
             .with_config(bruker_spectrum_processor)
             .finalize()?;
+        let mut spectra = self.read_msn_spectra(file_id, &spectrum_reader)?;
+        if requires_ms1 {
+            let ms1s = self.read_ms1_spectra(&path_name, file_id, &spectrum_reader)?;
+            spectra.extend(ms1s);
+        }
+
+        Ok(spectra)
+    }
+
+    fn read_ms1_spectra(&self, path_name: impl AsRef<str>, file_id: usize, spectrum_reader: &SpectrumReader) -> Result<Vec<RawSpectrum>, timsrust::TimsRustError> {
+        let start = std::time::Instant::now();
+        let frame_reader = timsrust::readers::FrameReader::new(path_name.as_ref())?;
+        let tdf_path = std::path::Path::new(path_name.as_ref()).join("analysis.tdf");
+        let metadata = timsrust::readers::MetadataReader::new(tdf_path)?;
+        let mz_converter = metadata.mz_converter;
+        let ims_converter = metadata.im_converter;
+
+        let ms1_spectra: Vec<RawSpectrum> = frame_reader
+            .parallel_filter(|f| f.ms_level == timsrust::MSLevel::MS1)
+            .filter_map(|frame| match frame {
+                Ok(frame) => {
+                    let mz: Vec<f32> = frame
+                        .tof_indices
+                        .iter()
+                        .map(|&x| mz_converter.convert(x as f64) as f32)
+                        .collect();
+                    let intensity: Vec<f32> = frame.intensities.iter().map(|&x| x as f32).collect();
+                    let mut imss: Vec<f32> = vec![0.0; mz.len()];
+                    // TODO: This is getting pretty big ... I should refactor this block.
+                    frame.scan_offsets.windows(2).enumerate().map(|(i, w)| {
+                        let num = w[1] - w[0];
+                        if num == 0 {
+                            return None;
+                        }
+                        let lo = w[0];
+                        let hi = w[1];
+
+                        let im = ims_converter.convert(i as f64) as f32;
+                        Some((im, lo, hi))
+                    }).for_each(|x| {
+                        if let Some((im, lo, hi)) = x {
+                            for i in lo..hi {
+                                imss[i] = im;
+                            }
+                        }
+                    });
+
+                    // Sort the mzs and intensities by mz
+                    let mut indices: Vec<usize> = (0..mz.len()).collect();
+                    indices.sort_by(|&i, &j| {
+                        mz[i]
+                            .partial_cmp(&mz[j])
+                            .unwrap_or(std::cmp::Ordering::Equal)
+                    });
+                    let sorted_mz: Vec<f32> = indices.iter().map(|&i| mz[i].clone()).collect();
+                    let sorted_inten: Vec<f32> =
+                        indices.iter().map(|&i| intensity[i].clone()).collect();
+                    let sorted_imss: Vec<f32> = indices.iter().map(|&i| imss[i].clone()).collect();
+
+                    // Squash the mobility dimension
+                    let tol_ppm = 15.0;
+                    let im_tol_pct = 2.0;
+                    let (mz, (intensity, mobility)): (Vec<f32>, (Vec<f32>, Vec<f32>)) = dumbcentroid_frame(&sorted_mz, &sorted_inten, &sorted_imss, tol_ppm, im_tol_pct);
+
+                    let scan_start_time = frame.rt as f32 / 60.0;
+                    let ion_injection_time = 100.0; // This is made up, in theory we can read
+                    // if from the tdf file
+                    let total_ion_current = sorted_inten.iter().sum::<f32>();
+                    let id = frame.index.to_string();
+
+                    let spec = RawSpectrum {
+                        file_id,
+                        precursors: vec![],
+                        representation: Representation::Centroid,
+                        scan_start_time,
+                        ion_injection_time,
+                        mz,
+                        ms_level: 1,
+                        id,
+                        intensity,
+                        total_ion_current,
+                        mobility: Some(mobility),
+                    };
+                    Some(spec)
+                }
+                Err(x) => {
+                    log::error!("error parsing spectrum: {:?}", x);
+                    None
+                }
+            }).collect();
+        log::info!("read {} ms1 spectra in {:#?}", ms1_spectra.len(), start.elapsed());
+        Ok(ms1_spectra)
+    }
+
+    fn read_msn_spectra(&self, file_id: usize, spectrum_reader: &SpectrumReader) -> Result<Vec<RawSpectrum>, timsrust::TimsRustError> {
         let spectra: Vec<RawSpectrum> = (0..spectrum_reader.len())
             .into_par_iter()
             .filter_map(|index| match spectrum_reader.get(index) {
@@ -39,6 +138,7 @@ impl TdfReader {
                             ms_level: 2,
                             id: dda_spectrum.index.to_string(),
                             intensity: dda_spectrum.intensities.iter().map(|&x| x as f32).collect(),
+                            mobility: None,
                         };
                         Some(spectrum)
                     }
@@ -66,3 +166,117 @@ impl TdfReader {
         precursor
     }
 }
+
+fn dumbcentroid_frame(mz_array: &[f32], intensity_array: &[f32], ims_array: &[f32], mz_tol_ppm: f32, im_tol_pct: f32) -> (Vec<f32>, (Vec<f32>, Vec<f32>)) {
+    // Make sure the mz array is sorted
+    assert!(mz_array.windows(2).all(|x| x[0] <= x[1]));
+
+    let arr_len = mz_array.len();
+    let mut touched = vec![false; arr_len];
+    let mut global_num_touched = 0;
+
+    let mut order: Vec<usize> = (0..arr_len).collect();
+    order.sort_unstable_by(|&a, &b| {
+        intensity_array[b]
+            .partial_cmp(&intensity_array[a])
+            .unwrap_or(Ordering::Equal)
+    });
+
+    #[derive(Debug, Clone, Copy, Default)]
+    struct ImsPeak {
+        mz: f32,
+        intensity: f32,
+        im: f32,
+    }
+    let mut agg_buff = Vec::with_capacity(10_000.min(arr_len));
+    let mut touch_buff = [false; 1000];
+
+    let utol = mz_tol_ppm / 1e6;
+    let im_tol = im_tol_pct / 100.0;
+
+    for &idx in &order {
+        if touched[idx] {
+            continue;
+        }
+
+        let mz = mz_array[idx];
+        let im = ims_array[idx];
+        let da_tol = mz * utol;
+        let left_e = mz - da_tol;
+        let right_e = mz + da_tol;
+
+        let ss_start = mz_array.partition_point(|&x| x < left_e);
+        let ss_end = mz_array.partition_point(|&x| x <= right_e);
+
+        let slice_width = ss_end - ss_start;
+        if slice_width > 1000 {
+            println!("slice_width: {}", slice_width);
+            println!("mz: {:.4}", mz);
+            println!("Limits: {:.4}, {:.4}", left_e, right_e);
+            println!("ss_start: {}, ss_end: {}", ss_start, ss_end);
+        }
+        let local_num_touched = touched[ss_start..ss_end].iter().filter(|&&x| x).count();
+        let local_num_untouched = slice_width - local_num_touched;
+
+        if local_num_touched == slice_width {
+            continue;
+        }
+
+        let abs_im_tol = im * im_tol;
+        let left_im = im - abs_im_tol;
+        let right_im = im + abs_im_tol;
+
+        let mut curr_intensity = 0.0;
+
+        let mut num_touchable = 0;
+        for i in ss_start..ss_end {
+            let im_i = ims_array[i];
+            if !touched[i] && intensity_array[i] > 0.0 && im_i >= left_im && im_i <= right_im {
+                curr_intensity += intensity_array[i];
+                num_touchable += 1;
+                touch_buff[i - ss_start] = true;
+            }
+        }
+
+        if curr_intensity > 0.0 {
+            agg_buff.push(ImsPeak {
+                mz,
+                intensity: curr_intensity,
+                im,
+            });
+            touched[ss_start..ss_end].iter_mut().zip(
+                touch_buff.iter_mut().take(slice_width)
+            ).for_each(|(t, tb)| {
+                *t = true;
+                *tb = false;
+            });
+            global_num_touched += num_touchable;
+            const MAX_PEAKS: usize = 10000;
+            if agg_buff.len() > MAX_PEAKS {
+                log::debug!("Reached limit of the agg buffer at index {}/{}", idx, arr_len);
+                break;
+            }
+        }
+
+        if global_num_touched == arr_len {
+            break;
+        }
+    }
+
+    assert!(touch_buff.iter().all(|x| !x), "{:?}", touch_buff);
+
+    // Drop the zeros and sort
+    // I could in theory truncate instead of filtering.
+    let mut result: Vec<(f32, (f32, f32))> = agg_buff.iter()
+        .filter(|&x| x.mz > 0.0 && x.intensity > 0.0)
+        .map(|x| (x.mz, (x.intensity, x.im as f32)))
+        .collect();
+
+    result.sort_unstable_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(Ordering::Equal));
+    // println!("Centroiding: Start len: {}; end len: {};", arr_len, result.len());
+    // Ultra data is usually start: 40k end 10k,
+    // HT2 data is usually start 400k end 40k
+
+    result.into_iter().unzip()
+}
+

--- a/crates/sage-cloudpath/src/tdf.rs
+++ b/crates/sage-cloudpath/src/tdf.rs
@@ -53,7 +53,11 @@ impl TdfReader {
                         .map(|&x| mz_converter.convert(x as f64) as f32)
                         .collect();
                     let corr_factor = frame.intensity_correction_factor as f32;
-                    let intensity: Vec<f32> = frame.intensities.iter().map(|&x| x as f32 * corr_factor).collect();
+                    let intensity: Vec<f32> = frame
+                        .intensities
+                        .iter()
+                        .map(|&x| x as f32 * corr_factor)
+                        .collect();
                     let imss = Self::expand_mobility(&frame.scan_offsets, &ims_converter);
                     assert_eq!(mz.len(), intensity.len(), "{:?}", frame);
                     assert_eq!(mz.len(), imss.len(), "{:?}", frame);
@@ -66,8 +70,7 @@ impl TdfReader {
                             .unwrap_or(std::cmp::Ordering::Equal)
                     });
                     let sorted_mz: Vec<f32> = indices.iter().map(|&i| mz[i]).collect();
-                    let sorted_inten: Vec<f32> =
-                        indices.iter().map(|&i| intensity[i]).collect();
+                    let sorted_inten: Vec<f32> = indices.iter().map(|&i| intensity[i]).collect();
                     let sorted_imss: Vec<f32> = indices.iter().map(|&i| imss[i]).collect();
 
                     // Squash the mobility dimension
@@ -197,14 +200,13 @@ impl TdfReader {
     }
 }
 
-
 /// Centroiding of the IM-containing spectra
 ///
 /// This is a very rudimentary centroiding algorithm but... it seems to work well.
 /// It iterativelty goes over the peaks in decreasing intensity order and
 /// accumulates the intensity of the peaks surrounding the peak. (sort of
 /// like the first pass in dbscan).
-/// 
+///
 /// This dramatically reduces the number of peaks in the spectra
 /// which saves a ton of memory and time when doing LFQ, since we
 /// iterate over each peak.
@@ -218,7 +220,10 @@ fn dumbcentroid_frame(
     // Make sure the mz array is sorted
     // In theory I could use the type system to enforce this but I dont
     // think it is worth it, its not that slow and its simple.
-    assert!(mz_array.windows(2).all(|x| x[0] <= x[1]), "mz_array is not sorted");
+    assert!(
+        mz_array.windows(2).all(|x| x[0] <= x[1]),
+        "mz_array is not sorted"
+    );
 
     let arr_len = mz_array.len();
     let mut global_num_included = 0;
@@ -309,7 +314,8 @@ fn dumbcentroid_frame(
     // rarely leaves peaks with intensity > 200 ... ive never seen
     // it happen. -JSP 2025-Jan
 
-    agg_buff.into_iter()
+    agg_buff
+        .into_iter()
         .map(|x| (x.mz, (x.intensity, x.im)))
         .unzip()
 }

--- a/crates/sage-cloudpath/src/util.rs
+++ b/crates/sage-cloudpath/src/util.rs
@@ -1,4 +1,4 @@
-use crate::{read_and_execute, tdf::BrukerSpectrumProcessor, Error};
+use crate::{read_and_execute, tdf::BrukerProcessingConfig, Error};
 use sage_core::spectrum::RawSpectrum;
 use serde::Serialize;
 use tokio::io::AsyncReadExt;
@@ -60,7 +60,7 @@ pub fn read_spectra<S: AsRef<str>>(
     path: S,
     file_id: usize,
     sn: Option<u8>,
-    bruker_processor: BrukerSpectrumProcessor,
+    bruker_processor: BrukerProcessingConfig,
     requires_ms1: bool,
 ) -> Result<Vec<RawSpectrum>, Error> {
     match FileFormat::from(path.as_ref()) {
@@ -87,7 +87,7 @@ pub fn read_mzml<S: AsRef<str>>(
 pub fn read_tdf<S: AsRef<str>>(
     s: S,
     file_id: usize,
-    bruker_spectrum_processor: BrukerSpectrumProcessor,
+    bruker_spectrum_processor: BrukerProcessingConfig,
     requires_ms1: bool,
 ) -> Result<Vec<RawSpectrum>, Error> {
     let res = crate::tdf::TdfReader.parse(s, file_id, bruker_spectrum_processor, requires_ms1);

--- a/crates/sage-cloudpath/src/util.rs
+++ b/crates/sage-cloudpath/src/util.rs
@@ -167,12 +167,12 @@ mod test {
 
     #[test]
     fn test_identify_format() {
-        assert_eq!(identify_format("foo.mzml"), FileFormat::MzML);
-        assert_eq!(identify_format("foo.mzML"), FileFormat::MzML);
-        assert_eq!(identify_format("foo.mgf"), FileFormat::MGF);
-        assert_eq!(identify_format("foo.mgf.gz"), FileFormat::MGF);
-        assert_eq!(identify_format("foo.tdf"), FileFormat::TDF);
-        assert_eq!(identify_format("./tomato/foo.d"), FileFormat::TDF);
-        assert_eq!(identify_format("./tomato/foo.d/"), FileFormat::TDF);
+        assert_eq!(FileFormat::from("foo.mzml"), FileFormat::MzML);
+        assert_eq!(FileFormat::from("foo.mzML"), FileFormat::MzML);
+        assert_eq!(FileFormat::from("foo.mgf"), FileFormat::MGF);
+        assert_eq!(FileFormat::from("foo.mgf.gz"), FileFormat::MGF);
+        assert_eq!(FileFormat::from("foo.tdf"), FileFormat::TDF);
+        assert_eq!(FileFormat::from("./tomato/foo.d"), FileFormat::TDF);
+        assert_eq!(FileFormat::from("./tomato/foo.d/"), FileFormat::TDF);
     }
 }

--- a/crates/sage-cloudpath/src/util.rs
+++ b/crates/sage-cloudpath/src/util.rs
@@ -43,11 +43,12 @@ pub fn read_spectra<S: AsRef<str>>(
     file_id: usize,
     sn: Option<u8>,
     bruker_processor: BrukerSpectrumProcessor,
+    requires_ms1: bool,
 ) -> Result<Vec<RawSpectrum>, Error> {
     match identify_format(path.as_ref()) {
         FileFormat::MzML => read_mzml(path, file_id, sn),
         FileFormat::MGF => read_mgf(path, file_id),
-        FileFormat::TDF => read_tdf(path, file_id, bruker_processor),
+        FileFormat::TDF => read_tdf(path, file_id, bruker_processor, requires_ms1),
         FileFormat::Unidentified => panic!("Unable to get type for '{}'", path.as_ref()), // read_mzml(path, file_id, sn),
     }
 }
@@ -69,8 +70,9 @@ pub fn read_tdf<S: AsRef<str>>(
     s: S,
     file_id: usize,
     bruker_spectrum_processor: BrukerSpectrumProcessor,
+    requires_ms1: bool,
 ) -> Result<Vec<RawSpectrum>, Error> {
-    let res = crate::tdf::TdfReader.parse(s, file_id, bruker_spectrum_processor);
+    let res = crate::tdf::TdfReader.parse(s, file_id, bruker_spectrum_processor, requires_ms1);
     match res {
         Ok(t) => Ok(t),
         Err(e) => Err(Error::TDF(e)),

--- a/crates/sage/Cargo.toml
+++ b/crates/sage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sage-core"
-version = "0.15.0-alpha"
+version = "0.16.0-beta.1"
 authors = ["Michael Lazear <michaellazear92@gmail.com"]
 edition = "2021"
 rust-version = "1.62"

--- a/crates/sage/src/database.rs
+++ b/crates/sage/src/database.rs
@@ -280,7 +280,7 @@ impl Parameters {
                     .flat_map(|kind| IonSeries::new(peptide, *kind).enumerate())
                     .filter(|(ion_idx, ion)| {
                         // Don't store b1, b2, y1, y2 ions for preliminary scoring
-                        
+
                         match ion.kind {
                             Kind::A | Kind::B | Kind::C => (ion_idx + 1) > self.min_ion_index,
                             Kind::X | Kind::Y | Kind::Z => {

--- a/crates/sage/src/database.rs
+++ b/crates/sage/src/database.rs
@@ -1,4 +1,4 @@
-use crate::enzyme::{Enzyme, EnzymeParameters};
+use crate::enzyme::{group_digests, Enzyme, EnzymeParameters};
 use crate::fasta::Fasta;
 use crate::ion_series::{IonSeries, Kind};
 use crate::mass::Tolerance;
@@ -166,6 +166,15 @@ impl Parameters {
         // and missed cleavages, if applicable.
         let digests = fasta.digest(&enzyme);
 
+        log::trace!("grouping digests");
+        let start_num = digests.len();
+        let digests = group_digests(digests);
+        log::trace!(
+            "grouped {} digests into {} groups",
+            start_num,
+            digests.len()
+        );
+
         let mods = self
             .variable_mods
             .iter()
@@ -175,9 +184,9 @@ impl Parameters {
         let targets: DashSet<_, FnvBuildHasher> = DashSet::default();
         digests
             .par_iter()
-            .filter(|digest| !digest.decoy)
+            .filter(|digest| !digest.reference.decoy)
             .for_each(|digest| {
-                targets.insert(digest.sequence.clone().into_bytes());
+                targets.insert(digest.reference.sequence.clone().into_bytes());
             });
 
         log::trace!("modifying peptides");
@@ -212,6 +221,7 @@ impl Parameters {
     pub fn reorder_peptides(target_decoys: &mut Vec<Peptide>) {
         log::trace!("sorting and deduplicating peptides");
 
+        let init_size = target_decoys.len();
         // This is equivalent to a stable sort
         target_decoys.par_sort_unstable_by(|a, b| {
             a.monoisotopic
@@ -219,7 +229,9 @@ impl Parameters {
                 .then_with(|| a.initial_sort(b))
         });
         target_decoys.dedup_by(|remove, keep| {
-            if remove.sequence == keep.sequence
+            if remove.monoisotopic == keep.monoisotopic
+            // if remove.sequence == keep.sequence
+                && remove.sequence == keep.sequence
                 && remove.modifications == keep.modifications
                 && remove.nterm == keep.nterm
                 && remove.cterm == keep.cterm
@@ -237,9 +249,20 @@ impl Parameters {
         target_decoys
             .par_iter_mut()
             .for_each(|peptide| peptide.proteins.sort_unstable());
+
+        let num_dropped = init_size - target_decoys.len();
+        let tot_proteins = target_decoys
+            .iter()
+            .map(|x| x.proteins.len())
+            .sum::<usize>();
+        log::trace!(
+            "dropped {} t/d pairs, remaining {}, tot_proteins: {}",
+            num_dropped,
+            target_decoys.len(),
+            tot_proteins
+        );
     }
 
-    // pub fn build(self) -> Result<IndexedDatabase, Box<dyn std::error::Error + Send + Sync + 'static>> {
     pub fn build(self, fasta: Fasta) -> IndexedDatabase {
         let target_decoys = self.digest(&fasta);
         self.build_from_peptides(target_decoys)
@@ -612,11 +635,11 @@ mod test {
             fasta.targets,
             vec![
                 (
-                    Arc::new("sp|AAAAA".to_string()),
+                    Arc::from("sp|AAAAA".to_string()),
                     "MEWKLEQSMREQALLKAQLTQLK".into()
                 ),
                 (
-                    Arc::new("sp|BBBBB".to_string()),
+                    Arc::from("sp|BBBBB".to_string()),
                     "RMEWKLEQSMREQALLKAQLTQLK".into()
                 ),
             ]
@@ -665,7 +688,7 @@ mod test {
 
         // All peptides are shared except for the protein N-term mod
         for peptide in &peptides[..4] {
-            assert_eq!(peptide.proteins.len(), 2);
+            assert_eq!(peptide.proteins.len(), 2, "{:?}", peptide);
         }
         // Ensure that this mod is uniquely called as the first protein
         assert_eq!(

--- a/crates/sage/src/fasta.rs
+++ b/crates/sage/src/fasta.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 #[derive(Clone)]
 pub struct Fasta {
-    pub targets: Vec<(Arc<String>, String)>,
+    pub targets: Vec<(Arc<str>, String)>,
     decoy_tag: String,
     // Should we ignore decoys in the fasta database
     // and generate them internally?
@@ -27,8 +27,8 @@ impl Fasta {
             let line = line.trim();
             if let Some(id) = line.strip_prefix('>') {
                 if !s.is_empty() {
-                    let acc: Arc<String> =
-                        Arc::new(last_id.split_ascii_whitespace().next().unwrap().to_string());
+                    let acc: Arc<str> =
+                        Arc::from(last_id.split_ascii_whitespace().next().unwrap().to_string());
                     let seq = std::mem::take(&mut s);
                     if !acc.contains(&decoy_tag) || !generate_decoys {
                         targets.push((acc, seq));
@@ -41,8 +41,8 @@ impl Fasta {
         }
 
         if !s.is_empty() {
-            let acc: Arc<String> =
-                Arc::new(last_id.split_ascii_whitespace().next().unwrap().to_string());
+            let acc: Arc<str> =
+                Arc::from(last_id.split_ascii_whitespace().next().unwrap().to_string());
             if !acc.contains(&decoy_tag) || !generate_decoys {
                 targets.push((acc, s));
             }

--- a/crates/sage/src/lfq.rs
+++ b/crates/sage/src/lfq.rs
@@ -106,9 +106,11 @@ pub fn build_feature_map(
                 // } else {
                 //     feat.calcmass
                 // };
-                let (mobility_lo, mobility_hi) =
-                        Tolerance::Pct(-settings.mobility_pct_tolerance, settings.mobility_pct_tolerance)
-                        .bounds(feat.ims);
+                let (mobility_lo, mobility_hi) = Tolerance::Pct(
+                    -settings.mobility_pct_tolerance,
+                    settings.mobility_pct_tolerance,
+                )
+                .bounds(feat.ims);
                 map.insert(
                     feat.peptide_idx,
                     PrecursorRange {

--- a/crates/sage/src/lfq.rs
+++ b/crates/sage/src/lfq.rs
@@ -180,7 +180,6 @@ pub fn build_feature_map(
         .collect::<Vec<_>>();
 
     log::trace!("building feature map");
-    println!("First feature map entry: {:?}", ranges.first());
     FeatureMap {
         ranges,
         min_rts,

--- a/crates/sage/src/mass.rs
+++ b/crates/sage/src/mass.rs
@@ -11,6 +11,7 @@ pub const NH3: f32 = 17.026548;
 #[serde(rename_all = "lowercase")]
 pub enum Tolerance {
     Ppm(f32, f32),
+    Pct(f32, f32),
     Da(f32, f32),
 }
 
@@ -22,6 +23,11 @@ impl Tolerance {
             Tolerance::Ppm(lo, hi) => {
                 let delta_lo = center * lo / 1_000_000.0;
                 let delta_hi = center * hi / 1_000_000.0;
+                (center + delta_lo, center + delta_hi)
+            }
+            Tolerance::Pct(lo, hi) => {
+                let delta_lo = center * lo / 100.0;
+                let delta_hi = center * hi / 100.0;
                 (center + delta_lo, center + delta_hi)
             }
             Tolerance::Da(lo, hi) => (center + lo, center + hi),
@@ -44,6 +50,7 @@ impl Mul<f32> for Tolerance {
     fn mul(self, rhs: f32) -> Self::Output {
         match self {
             Tolerance::Ppm(lo, hi) => Tolerance::Ppm(lo * rhs, hi * rhs),
+            Tolerance::Pct(lo, hi) => Tolerance::Pct(lo * rhs, hi * rhs),
             Tolerance::Da(lo, hi) => Tolerance::Da(lo * rhs, hi * rhs),
         }
     }

--- a/crates/sage/src/ml/linear_discriminant.rs
+++ b/crates/sage/src/ml/linear_discriminant.rs
@@ -42,7 +42,7 @@ const FEATURE_NAMES: [&str; FEATURES] = [
 
 struct Features<'a>(&'a [f64]);
 
-impl<'a> std::fmt::Debug for Features<'a> {
+impl std::fmt::Debug for Features<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_map()
             .entries(FEATURE_NAMES.iter().zip(self.0))
@@ -131,11 +131,13 @@ pub fn score_psms(scores: &mut [Feature], precursor_tol: Tolerance) -> Option<()
 
     let mass_error = match precursor_tol {
         Tolerance::Ppm(_, _) => |feat: &Feature| feat.delta_mass as f64,
+        Tolerance::Pct(_, _) => unreachable!("Pct tolerance should never be used on mz"),
         Tolerance::Da(_, _) => |feat: &Feature| (feat.expmass - feat.calcmass) as f64,
     };
 
     let (bw_adjust, bin_size) = match precursor_tol {
         Tolerance::Ppm(lo, hi) => (2.0f64, (hi - lo).max(100.0)),
+        Tolerance::Pct(_, _) => unreachable!("Pct tolerance should never be used on mz"),
         Tolerance::Da(lo, hi) => (0.1f64, (hi - lo).max(1000.0)),
     };
 

--- a/crates/sage/src/peptide.rs
+++ b/crates/sage/src/peptide.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, fmt::Debug, sync::Arc};
 
 use crate::modification::ModificationSpecificity;
 use crate::{
-    enzyme::{Digest, Position},
+    enzyme::{Digest, DigestGroup, Position},
     mass::{monoisotopic, H2O},
 };
 use fnv::FnvHashSet;
@@ -27,7 +27,7 @@ pub struct Peptide {
     /// Where is this peptide located in the protein?
     pub position: Position,
 
-    pub proteins: Vec<Arc<String>>,
+    pub proteins: Vec<Arc<str>>,
 }
 
 impl Peptide {
@@ -342,6 +342,16 @@ enum Site {
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum PeptideError {
     InvalidSequence(String),
+}
+
+impl TryFrom<DigestGroup> for Peptide {
+    type Error = PeptideError;
+
+    fn try_from(value: DigestGroup) -> Result<Self, Self::Error> {
+        let mut pep = Peptide::try_from(value.reference)?;
+        pep.proteins = value.proteins;
+        Ok(pep)
+    }
 }
 
 impl TryFrom<Digest> for Peptide {

--- a/crates/sage/src/scoring.rs
+++ b/crates/sage/src/scoring.rs
@@ -2,7 +2,7 @@ use crate::database::{IndexedDatabase, PeptideIx};
 use crate::heap::bounded_min_heapify;
 use crate::ion_series::{IonSeries, Kind};
 use crate::mass::{Tolerance, NEUTRON, PROTON};
-use crate::spectrum::{Precursor, ProcessedSpectrum};
+use crate::spectrum::{Peak, Precursor, ProcessedSpectrum};
 use serde::{Deserialize, Serialize};
 use std::ops::AddAssign;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -245,7 +245,7 @@ fn max_fragment_charge(max_fragment_charge: Option<u8>, precursor_charge: u8) ->
 impl<'db> Scorer<'db> {
     pub fn quick_score(
         &self,
-        query: &ProcessedSpectrum,
+        query: &ProcessedSpectrum<Peak>,
         prefilter_low_memory: bool,
     ) -> Vec<PeptideIx> {
         assert_eq!(
@@ -284,7 +284,7 @@ impl<'db> Scorer<'db> {
         }
     }
 
-    pub fn score(&self, query: &ProcessedSpectrum) -> Vec<Feature> {
+    pub fn score(&self, query: &ProcessedSpectrum<crate::spectrum::Peak>) -> Vec<Feature> {
         assert_eq!(
             query.level, 2,
             "internal bug, trying to score a non-MS2 scan!"
@@ -321,7 +321,7 @@ impl<'db> Scorer<'db> {
     /// in sorted order.
     fn matched_peaks_with_isotope(
         &self,
-        query: &ProcessedSpectrum,
+        query: &ProcessedSpectrum<crate::spectrum::Peak>,
         precursor_mass: f32,
         precursor_charge: u8,
         precursor_tol: Tolerance,
@@ -369,7 +369,7 @@ impl<'db> Scorer<'db> {
 
     fn matched_peaks(
         &self,
-        query: &ProcessedSpectrum,
+        query: &ProcessedSpectrum<Peak>,
         precursor_mass: f32,
         precursor_charge: u8,
         precursor_tol: Tolerance,
@@ -401,7 +401,7 @@ impl<'db> Scorer<'db> {
         }
     }
 
-    fn initial_hits(&self, query: &ProcessedSpectrum, precursor: &Precursor) -> InitialHits {
+    fn initial_hits(&self, query: &ProcessedSpectrum<Peak>, precursor: &Precursor) -> InitialHits {
         // Sage operates on masses without protons; [M] instead of [MH+]
         let mz = precursor.mz - PROTON;
 
@@ -448,7 +448,7 @@ impl<'db> Scorer<'db> {
     }
 
     /// Score a single [`ProcessedSpectrum`] against the database
-    pub fn score_standard(&self, query: &ProcessedSpectrum) -> Vec<Feature> {
+    pub fn score_standard(&self, query: &ProcessedSpectrum<Peak>) -> Vec<Feature> {
         let precursor = query.precursors.first().unwrap_or_else(|| {
             panic!("missing MS1 precursor for {}", query.id);
         });
@@ -463,7 +463,7 @@ impl<'db> Scorer<'db> {
     /// best PSMs ([`Feature`])
     fn build_features(
         &self,
-        query: &ProcessedSpectrum,
+        query: &ProcessedSpectrum<Peak>,
         precursor: &Precursor,
         hits: &InitialHits,
         report_psms: usize,
@@ -576,7 +576,7 @@ impl<'db> Scorer<'db> {
     }
 
     /// Remove peaks matching a PSM from a query spectrum
-    fn remove_matched_peaks(&self, query: &mut ProcessedSpectrum, psm: &Feature) {
+    fn remove_matched_peaks(&self, query: &mut ProcessedSpectrum<Peak>, psm: &Feature) {
         let peptide = &self.db[psm.peptide_idx];
         let fragments = self
             .db
@@ -612,7 +612,7 @@ impl<'db> Scorer<'db> {
 
     /// Return multiple PSMs for each spectra - first is the best match, second PSM is the best match
     /// after all theoretical peaks assigned to the best match are removed, etc
-    pub fn score_chimera_fast(&self, query: &ProcessedSpectrum) -> Vec<Feature> {
+    pub fn score_chimera_fast(&self, query: &ProcessedSpectrum<Peak>) -> Vec<Feature> {
         let precursor = query.precursors.first().unwrap_or_else(|| {
             panic!("missing MS1 precursor for {}", query.id);
         });
@@ -641,7 +641,7 @@ impl<'db> Scorer<'db> {
     /// Calculate full hyperscore for a given PSM
     fn score_candidate(
         &self,
-        query: &ProcessedSpectrum,
+        query: &ProcessedSpectrum<Peak>,
         pre_score: &PreScore,
     ) -> (Score, Option<Fragments>) {
         let mut score = Score {

--- a/crates/sage/src/spectrum.rs
+++ b/crates/sage/src/spectrum.rs
@@ -1,5 +1,6 @@
 use crate::database::binary_search_slice;
 use crate::mass::{Tolerance, NEUTRON, PROTON};
+use crate::spectrum;
 
 /// A charge-less peak at monoisotopic mass
 #[derive(PartialEq, Copy, Clone, Default, Debug)]
@@ -21,6 +22,31 @@ impl Ord for Peak {
         self.intensity
             .total_cmp(&other.intensity)
             .then_with(|| self.mass.total_cmp(&other.mass))
+    }
+}
+
+/// A charge-less peak at monoisotopic mass with ion mobility
+#[derive(PartialEq, Copy, Clone, Default, Debug)]
+pub struct IMPeak {
+    pub intensity: f32,
+    pub mass: f32,
+    pub mobility: f32, // I would use f16 but its not stable
+}
+
+impl Eq for IMPeak {}
+
+impl PartialOrd for IMPeak {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for IMPeak {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.intensity
+            .total_cmp(&other.intensity)
+            .then_with(|| self.mass.total_cmp(&other.mass))
+            .then_with(|| self.mobility.total_cmp(&other.mobility))
     }
 }
 
@@ -55,7 +81,7 @@ pub struct Precursor {
 }
 
 #[derive(Clone, Default, Debug)]
-pub struct ProcessedSpectrum {
+pub struct ProcessedSpectrum<T> {
     /// MSn level
     pub level: u8,
     /// Scan ID
@@ -69,7 +95,7 @@ pub struct ProcessedSpectrum {
     /// Selected ions for precursors, if `level > 1`
     pub precursors: Vec<Precursor>,
     /// MS peaks, sorted by mass in ascending order
-    pub peaks: Vec<Peak>,
+    pub peaks: Vec<T>,
     /// Total ion current
     pub total_ion_current: f32,
 }
@@ -97,6 +123,8 @@ pub struct RawSpectrum {
     pub mz: Vec<f32>,
     /// Intensity array
     pub intensity: Vec<f32>,
+    /// Mobility array
+    pub mobility: Option<Vec<f32>>,
 }
 
 impl RawSpectrum {
@@ -119,6 +147,18 @@ pub enum Representation {
 impl Default for Representation {
     fn default() -> Self {
         Self::Profile
+    }
+}
+
+pub enum MS1Spectra {
+    NoMobility(Vec<ProcessedSpectrum<Peak>>),
+    WithMobility(Vec<ProcessedSpectrum<IMPeak>>),
+    Empty,
+}
+
+impl Default for MS1Spectra {
+    fn default() -> Self {
+        Self::Empty
     }
 }
 
@@ -237,14 +277,13 @@ pub fn path_compression(peaks: &mut [Deisotoped]) {
     }
 }
 
-impl ProcessedSpectrum {
+impl <T>ProcessedSpectrum<T> {
     pub fn extract_ms1_precursor(&self) -> Option<(f32, u8)> {
         let precursor = self.precursors.first()?;
         let charge = precursor.charge?;
         let mass = (precursor.mz - PROTON) * charge as f32;
         Some((mass, charge))
     }
-
     pub fn in_isolation_window(&self, mz: f32) -> Option<bool> {
         let precursor = self.precursors.first()?;
         let (lo, hi) = precursor.isolation_window?.bounds(precursor.mz - PROTON);
@@ -327,7 +366,7 @@ impl SpectrumProcessor {
         }
     }
 
-    pub fn process(&self, spectrum: RawSpectrum) -> ProcessedSpectrum {
+    pub fn process(&self, spectrum: RawSpectrum) -> ProcessedSpectrum<Peak> {
         let mut peaks = match spectrum.ms_level {
             2 => self.process_ms2(self.deisotope, &spectrum),
             _ => spectrum
@@ -340,6 +379,34 @@ impl SpectrumProcessor {
                 })
                 .collect::<Vec<_>>(),
         };
+
+        peaks.sort_by(|a, b| a.mass.total_cmp(&b.mass));
+        let total_ion_current = peaks.iter().map(|peak| peak.intensity).sum::<f32>();
+
+        ProcessedSpectrum {
+            level: spectrum.ms_level,
+            id: spectrum.id,
+            file_id: spectrum.file_id,
+            scan_start_time: spectrum.scan_start_time,
+            ion_injection_time: spectrum.ion_injection_time,
+            precursors: spectrum.precursors,
+            peaks,
+            total_ion_current,
+        }
+    }
+
+    pub fn process_with_mobility(&self, spectrum: RawSpectrum) -> ProcessedSpectrum<IMPeak> {
+        assert!(spectrum.ms_level == 1, "Logic error, mobility processing should only be used for MS1");
+        let mut peaks = spectrum
+            .mz
+            .iter()
+            .zip(spectrum.intensity.iter().zip(spectrum.mobility.unwrap().iter()))
+            .map(|(&mass, (&intensity, &mobility))| {
+                let mass = (mass - PROTON) * 1.0;
+                IMPeak { mass, intensity, mobility }
+            })
+            .collect::<Vec<_>>();
+        
 
         peaks.sort_by(|a, b| a.mass.total_cmp(&b.mass));
         let total_ion_current = peaks.iter().map(|peak| peak.intensity).sum::<f32>();

--- a/crates/sage/src/spectrum.rs
+++ b/crates/sage/src/spectrum.rs
@@ -1,6 +1,5 @@
 use crate::database::binary_search_slice;
 use crate::mass::{Tolerance, NEUTRON, PROTON};
-use crate::spectrum;
 
 /// A charge-less peak at monoisotopic mass
 #[derive(PartialEq, Copy, Clone, Default, Debug)]

--- a/crates/sage/src/spectrum.rs
+++ b/crates/sage/src/spectrum.rs
@@ -277,7 +277,7 @@ pub fn path_compression(peaks: &mut [Deisotoped]) {
     }
 }
 
-impl <T>ProcessedSpectrum<T> {
+impl<T> ProcessedSpectrum<T> {
     pub fn extract_ms1_precursor(&self) -> Option<(f32, u8)> {
         let precursor = self.precursors.first()?;
         let charge = precursor.charge?;
@@ -396,17 +396,28 @@ impl SpectrumProcessor {
     }
 
     pub fn process_with_mobility(&self, spectrum: RawSpectrum) -> ProcessedSpectrum<IMPeak> {
-        assert!(spectrum.ms_level == 1, "Logic error, mobility processing should only be used for MS1");
+        assert!(
+            spectrum.ms_level == 1,
+            "Logic error, mobility processing should only be used for MS1"
+        );
         let mut peaks = spectrum
             .mz
             .iter()
-            .zip(spectrum.intensity.iter().zip(spectrum.mobility.unwrap().iter()))
+            .zip(
+                spectrum
+                    .intensity
+                    .iter()
+                    .zip(spectrum.mobility.unwrap().iter()),
+            )
             .map(|(&mass, (&intensity, &mobility))| {
                 let mass = (mass - PROTON) * 1.0;
-                IMPeak { mass, intensity, mobility }
+                IMPeak {
+                    mass,
+                    intensity,
+                    mobility,
+                }
             })
             .collect::<Vec<_>>();
-        
 
         peaks.sort_by(|a, b| a.mass.total_cmp(&b.mass));
         let total_ion_current = peaks.iter().map(|peak| peak.intensity).sum::<f32>();

--- a/crates/sage/src/tmt.rs
+++ b/crates/sage/src/tmt.rs
@@ -183,7 +183,7 @@ pub struct Quant<'ms3> {
     /// Quanitified TMT reporter ion intensities
     pub intensities: Vec<Option<&'ms3 Peak>>,
     /// MS3 spectrum
-    pub spectrum: &'ms3 ProcessedSpectrum,
+    pub spectrum: &'ms3 ProcessedSpectrum<Peak>,
 }
 
 /// Return a vector containing the peaks closest to the m/zs defined in
@@ -305,7 +305,7 @@ pub struct TmtQuant {
 /// * `isobaric_tolerance`: specify label tolerance
 /// * `level`: MSn level to extract isobaric peaks from
 pub fn quantify(
-    spectra: &[ProcessedSpectrum],
+    spectra: &[ProcessedSpectrum<Peak>],
     isobaric_labels: &Isobaric,
     isobaric_tolerance: Tolerance,
     level: u8,


### PR DESCRIPTION
This PR actually contains 2 features that are not really related to one another (which ended up combined bc of skill issues using git worktrees … LMK if you really want me to split them into separate PRs)

# Initial support for LFQ on data with ion mobility.

This supersedes: https://github.com/lazear/sage/pull/156

**What** are the key elements of this solution?

- Adds the parsing-reading of the IM-containing spectra from tdf files.
    - Storing all peaks was very slow, so I also added a way to do some
      centroiding on the data. Which is very rudimentary right now but
      seems to work well.
- Splits the `ProcessedSpectrum` struct into two variants, one where the elements
  are `ProcessedSpectrum<Peak>`s (mz-int) and one where they are 
  `ProcessedSpectrum<IMPeak>`s (mz-int-mobility).
- Adds a new `MS1Spectra` enum that can be either `NoMobility` or `WithMobility`
  which is passed with the search results to the LFQ code (so it filters on IM
  on top of the mz).
- Implements the differential handling of the two variants in the `FeatureMap`
- Adds a variant of the Tolerance enum to be 'Pct' (percent), since it makes a lot
  more sense for the scale of the mobility.

The bulk of the changes for this are -> 
- crates/sage-cloudpath/src/tdf.rs
- crates/sage/src/lfq.rs
- crates/sage/src/spectrum.rs

**Why** did you design your solution this way? Did you assess any alternatives? Are there tradeoffs?

- I believe this greatly improves the quant quality because it removes noise from irrelevant
  sections of the mobility range (which makes this PR supersede the previous attempt).
- Tradeoffs:
  - It adds one f32 to the size of the `PrecursorRange` and one optional vec to the size
    of the `RawSpectrum` (which I feel should be fine) ... In theory the `RawSpectrum`
    could be written to a generic and that gets propagated throughout the program
    which would make the change 'zero-cost' but it felt really hard to do... (it is 
    a lot of re-writing + added complexity).
- Right now the mobility range used for centroiding (but not LFQ) is hard-coded, we
  could add it as parameters to the config and propagate it throughout the program.
  I am not sure where this would go in the input file (either close to `min_peak` 
  or within the bruker processor)

# Speedup on the generation of databases when large number of peptides are redundant.

This solution drops the library generation time from 45-50 seconds to 12-16 on a particularly redundant database in my laptop.

**What** are the key elements of this solution?

There are two/three main changes:

1. Changing the instances of `Aec<String>` to `Arc<str>` (which were used to track the
   protein accessions). This speeds up the comparison of the sequences since the arc
   pointer goes directly to the sequence, instead of going to the String that points
   to the sequence (... I think). and (I think) saves a couple of bytes in the heap
   (not in number of allocations but in final size).
2. Additional deduplication stage at the digest level (which is done introducing the
   `DigestGroup` struct). This dramatically speeds up building libraries where many
   proteins share peptides (isoform fasta files for instance).
3. Using the monoisoropic mass for the comparison of the peptide for deduplication.
   These were being used for sorting but not for deduplication.

**Why** did you design your solution this way? Did you assess any alternatives? Are there tradeoffs?

- In theory this will be a bit slower in libraries that have many single-peptide-unique
  proteins, where nothing needs to be deduplicated but dont see it being a big deal in
  practice.

## Extras

Does this PR require a change to the docs?
- [ ] No.
- [ ] Yes, and I have opened a PR at ...
- [x] Yes; I haven't opened a PR, but the gist of the change is: 
    - New parameter for the IM tolerance in the LFQ section of the docs.
    - I also noticed that none of the config for the bruker processing is documented ...

Did you add or update tests for this change?
- [x] Yes. The only changes in tests were to change Arc::new(String) to Arc::from(String).
- [x] No, I believe tests aren't necessary. No tests were added but the changes are tested by sage_core::database::digestion test.

Please complete the following checklist:
- [x] I have added an entry to `CHANGELOG.md`, under the `[Unreleased]` section heading. That entry references the issue closed by this PR.
- [x] I acknowledge Sage's license. I do not own my contribution.

NOTE: teplate for the PR is here: https://raw.githubusercontent.com/tconbeer/harlequin/refs/heads/main/.github/PULL_REQUEST_TEMPLATE.md

Extras:
- I am not the biggest fan of how `SpectrumReaderConfig` is implemented RN ... I think we should re-write it to a config within sage (which implements Into:: -> to the timsrust-native ones) ... also this is not documented anywhere ... (which I guess is fine bc its pretty experimental ...)
- @sander-willems-bruker How hard would it be to implement a way to get the `Metadata` struct from a reader? RN I am doing this in a very hacky way (looking for the `analysis.tdf`, but I am not sure if this would work with the mini-tdf or the other variants supported by timsrust)