### PR TITLE
CI: Docker user user instead of `lazear` as a container name

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: lazear/sage
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build:


### PR DESCRIPTION
Well this is mostly to allow forks to run the full CI ... not really a lot otherwise ...