### PR TITLE
refactor: Move Peaks from AOS to SOA

### DIFF
--- a/crates/sage-cli/src/output.rs
+++ b/crates/sage-cli/src/output.rs
@@ -1,12 +1,21 @@
 use rayon::prelude::*;
-use sage_core::spectrum::MS1Spectra;
+use sage_core::spectrum::ProcessedSpectrum;
 use sage_core::{scoring::Feature, tmt::TmtQuant};
 
 #[derive(Default)]
 pub struct SageResults {
-    pub ms1: MS1Spectra,
+    pub ms1: Vec<ProcessedSpectrum>,
     pub features: Vec<Feature>,
     pub quant: Vec<TmtQuant>,
+}
+
+impl SageResults {
+    fn fold(mut self, other: SageResults) -> Self {
+        self.features.extend(other.features);
+        self.quant.extend(other.quant);
+        self.ms1.extend(other.ms1);
+        self
+    }
 }
 
 impl FromParallelIterator<SageResults> for SageResults {
@@ -16,39 +25,7 @@ impl FromParallelIterator<SageResults> for SageResults {
     {
         par_iter
             .into_par_iter()
-            .reduce(SageResults::default, |mut acc, x| {
-                acc.features.extend(x.features);
-                acc.quant.extend(x.quant);
-                match (acc.ms1, x.ms1) {
-                    (MS1Spectra::NoMobility(mut a), MS1Spectra::NoMobility(b)) => {
-                        a.extend(b);
-                        acc.ms1 = MS1Spectra::NoMobility(a);
-                    }
-                    (MS1Spectra::WithMobility(mut a), MS1Spectra::WithMobility(b)) => {
-                        a.extend(b);
-                        acc.ms1 = MS1Spectra::WithMobility(a);
-                    }
-                    (MS1Spectra::Empty, MS1Spectra::Empty) => {
-                        acc.ms1 = MS1Spectra::Empty;
-                    }
-                    (MS1Spectra::Empty, MS1Spectra::WithMobility(a))
-                    | (MS1Spectra::WithMobility(a), MS1Spectra::Empty) => {
-                        acc.ms1 = MS1Spectra::WithMobility(a);
-                    }
-                    (MS1Spectra::Empty, MS1Spectra::NoMobility(a))
-                    | (MS1Spectra::NoMobility(a), MS1Spectra::Empty) => {
-                        acc.ms1 = MS1Spectra::NoMobility(a);
-                    }
-                    _ => {
-                        // In theory this can happen if someone is searching
-                        // together files of different types, mixing the ones
-                        // that support IMS and the ones that dont.
-                        // ... I dont think this should be run-time recoverable.
-                        unreachable!("Found combination of MS1 spectra with and without mobility.")
-                    }
-                };
-                acc
-            })
+            .reduce(SageResults::default, SageResults::fold)
     }
 }
 
@@ -59,34 +36,6 @@ impl FromIterator<SageResults> for SageResults {
     {
         par_iter
             .into_iter()
-            .fold(SageResults::default(), |mut acc, x| {
-                acc.features.extend(x.features);
-                acc.quant.extend(x.quant);
-                match (acc.ms1, x.ms1) {
-                    (MS1Spectra::NoMobility(mut a), MS1Spectra::NoMobility(b)) => {
-                        a.extend(b);
-                        acc.ms1 = MS1Spectra::NoMobility(a);
-                    }
-                    (MS1Spectra::WithMobility(mut a), MS1Spectra::WithMobility(b)) => {
-                        a.extend(b);
-                        acc.ms1 = MS1Spectra::WithMobility(a);
-                    }
-                    (MS1Spectra::Empty, MS1Spectra::Empty) => {
-                        acc.ms1 = MS1Spectra::Empty;
-                    }
-                    (MS1Spectra::Empty, MS1Spectra::WithMobility(a))
-                    | (MS1Spectra::WithMobility(a), MS1Spectra::Empty) => {
-                        acc.ms1 = MS1Spectra::WithMobility(a);
-                    }
-                    (MS1Spectra::Empty, MS1Spectra::NoMobility(a))
-                    | (MS1Spectra::NoMobility(a), MS1Spectra::Empty) => {
-                        acc.ms1 = MS1Spectra::NoMobility(a);
-                    }
-                    _ => {
-                        unreachable!("Found combination of MS1 spectra with and without mobility.")
-                    }
-                };
-                acc
-            })
+            .fold(SageResults::default(), SageResults::fold)
     }
 }

--- a/crates/sage-cli/src/runner.rs
+++ b/crates/sage-cli/src/runner.rs
@@ -14,7 +14,7 @@ use sage_core::mass::Tolerance;
 use sage_core::peptide::Peptide;
 use sage_core::scoring::Fragments;
 use sage_core::scoring::{Feature, Scorer};
-use sage_core::spectrum::{MS1Spectra, ProcessedSpectrum, RawSpectrum, SpectrumProcessor};
+use sage_core::spectrum::{ProcessedSpectrum, RawSpectrum, SpectrumProcessor};
 use sage_core::tmt::TmtQuant;
 use std::collections::HashMap;
 use std::collections::HashSet;
@@ -136,8 +136,8 @@ impl Runner {
 
     pub fn prefilter_peptides(self, parallel: usize, fasta: Fasta) -> Vec<Peptide> {
         let spectra: Option<(
-            MS1Spectra,
-            Vec<ProcessedSpectrum<sage_core::spectrum::Peak>>,
+            Vec<ProcessedSpectrum>,
+            Vec<ProcessedSpectrum>,
         )> = match parallel >= self.parameters.mzml_paths.len() {
             true => Some(self.read_processed_spectra(&self.parameters.mzml_paths, 0, 0)),
             false => None,
@@ -207,7 +207,7 @@ impl Runner {
     fn peptide_filter_processed_spectra(
         &self,
         scorer: &Scorer,
-        spectra: &Vec<ProcessedSpectrum<sage_core::spectrum::Peak>>,
+        spectra: &Vec<ProcessedSpectrum>,
     ) -> Vec<PeptideIx> {
         use std::sync::atomic::{AtomicUsize, Ordering};
         let counter = AtomicUsize::new(0);
@@ -215,7 +215,7 @@ impl Runner {
 
         let peptide_idxs: Vec<_> = spectra
             .par_iter()
-            .filter(|spec| spec.peaks.len() >= self.parameters.min_peaks && spec.level == 2)
+            .filter(|spec| spec.masses.len() >= self.parameters.min_peaks && spec.level == 2)
             .map(|x| {
                 let prev = counter.fetch_add(1, Ordering::Relaxed);
                 if prev > 0 && prev % 10_000 == 0 {
@@ -262,7 +262,7 @@ impl Runner {
     fn search_processed_spectra(
         &self,
         scorer: &Scorer,
-        msn_spectra: &Vec<ProcessedSpectrum<sage_core::spectrum::Peak>>,
+        msn_spectra: &Vec<ProcessedSpectrum>,
     ) -> Vec<Feature> {
         use std::sync::atomic::{AtomicUsize, Ordering};
         let counter = AtomicUsize::new(0);
@@ -270,7 +270,7 @@ impl Runner {
 
         let features: Vec<_> = msn_spectra
             .par_iter()
-            .filter(|spec| spec.peaks.len() >= self.parameters.min_peaks && spec.level == 2)
+            .filter(|spec| spec.masses.len() >= self.parameters.min_peaks && spec.level == 2)
             .map(|x| {
                 let prev = counter.fetch_add(1, Ordering::Relaxed);
                 if prev > 0 && prev % 10_000 == 0 {
@@ -293,8 +293,8 @@ impl Runner {
 
     fn complete_features(
         &self,
-        msn_spectra: Vec<ProcessedSpectrum<sage_core::spectrum::Peak>>,
-        ms1_spectra: MS1Spectra,
+        msn_spectra: Vec<ProcessedSpectrum>,
+        ms1_spectra: Vec<ProcessedSpectrum>,
         features: Vec<Feature>,
     ) -> SageResults {
         let quant = self
@@ -340,8 +340,8 @@ impl Runner {
         chunk_idx: usize,
         batch_size: usize,
     ) -> (
-        MS1Spectra,
-        Vec<ProcessedSpectrum<sage_core::spectrum::Peak>>,
+        Vec<ProcessedSpectrum>,
+        Vec<ProcessedSpectrum>,
     ) {
         // Read all of the spectra at once - this can help prevent memory over-consumption issues
         info!(
@@ -430,19 +430,17 @@ impl Runner {
         let ms1_empty = spectra.ms1.is_empty();
         let ms1_spectra = if ms1_empty {
             log::trace!("no MS1 spectra found");
-            MS1Spectra::Empty
+            vec![]
         } else if all_contain_ims {
             log::trace!("Processing MS1 spectra with IMS");
-            let spectra = spectra
+            spectra
                 .ms1
                 .into_iter()
                 .map(|x| sp.process_with_mobility(x))
-                .collect();
-            MS1Spectra::WithMobility(spectra)
+                .collect()
         } else {
             log::trace!("Processing MS1 spectra without IMS");
-            let spectra = spectra.ms1.into_iter().map(|s| sp.process(s)).collect();
-            MS1Spectra::NoMobility(spectra)
+            spectra.ms1.into_iter().map(|s| sp.process(s)).collect()
         };
 
         let io_time = Instant::now() - start;

--- a/crates/sage-cli/tests/integration.rs
+++ b/crates/sage-cli/tests/integration.rs
@@ -15,7 +15,7 @@ fn integration() -> anyhow::Result<()> {
 
     let sp = SpectrumProcessor::new(100, true, 0.0);
     let processed = sp.process(spectra[0].clone());
-    assert!(processed.peaks.len() <= 300);
+    assert!(processed.masses.len() <= 300);
 
     let scorer = Scorer {
         db: &database,

--- a/crates/sage-cloudpath/src/tdf.rs
+++ b/crates/sage-cloudpath/src/tdf.rs
@@ -221,7 +221,7 @@ impl PeakBuffer {
 
         // The "order" is sorted by intensity
         // This will be used later during the centroiding (for details check that implementation)
-        self.order.extend((0..self.len()));
+        self.order.extend(0..self.len());
         self.order.sort_unstable_by(|&a, &b| {
             self.peaks[b]
                 .intensity
@@ -375,7 +375,7 @@ impl PeakBuffer {
             global_num_included += num_includable;
 
             if global_num_included == self.len() {
-                log::debug!("All peaks were included in the centroiding");
+                log::trace!("All peaks were included in the centroiding");
                 break;
             }
         }

--- a/crates/sage/src/fdr.rs
+++ b/crates/sage/src/fdr.rs
@@ -235,7 +235,7 @@ pub fn picked_precursor(
         .map(|score| ((score.ix, score.decoy), score.q))
         .collect::<FnvHashMap<_, _>>();
 
-    peaks.par_iter_mut().for_each(|((ix), (peak, _))| {
+    peaks.par_iter_mut().for_each(|(ix, (peak, _))| {
         peak.q_value = scores[ix];
     });
     passing

--- a/crates/sage/src/modification.rs
+++ b/crates/sage/src/modification.rs
@@ -4,7 +4,7 @@ use std::{
     str::FromStr,
 };
 
-use serde::{de::Visitor, Deserialize, Serialize};
+use serde::Serialize;
 
 use crate::mass::VALID_AA;
 


### PR DESCRIPTION
https://github.com/lazear/sage/pull/166#issuecomment-2784657830

This PR removes the `MS1Spectra` and the generic peak/imspeak in `ProcessedSpectrum`

LMK if this is what you had in mind ... RN I am not the biggest fan of a couple of places in the processing where I am zipping->unzipping to sort the peaks (which is why I am leaving it as a draft for now).

In my benchmarking it is almost as fast as the other implementation (runtime is maybe 2% slower in my computer and that matches the number of instructions retired on some random data)

LMK what you think! (or feel free to take it as a base to go off ...)