### PR TITLE
fix: track charges on deisotoped ions (#220)

### DIFF
--- a/crates/sage/src/scoring.rs
+++ b/crates/sage/src/scoring.rs
@@ -151,6 +151,7 @@ pub struct Feature {
 /// Matching Fragment details
 #[derive(Serialize, Default, Clone, Debug)]
 pub struct Fragments {
+    /// Observed fragment charge state.
     #[serde(skip_serializing)]
     pub charges: Vec<i32>,
     pub kinds: Vec<Kind>,
@@ -617,20 +618,30 @@ impl<'db> Scorer<'db> {
                     self.fragment_tol,
                     None,
                 ) {
-                    to_remove.push((query.masses[peak_idx], query.intensities[peak_idx]));
+                    to_remove.push((
+                        query.masses[peak_idx],
+                        query.intensities[peak_idx],
+                        query.charges[peak_idx],
+                    ));
                 }
             }
         }
 
         let mut masses = Vec::with_capacity(query.masses.len());
         let mut intensities = Vec::with_capacity(query.intensities.len());
+        let mut charges = Vec::with_capacity(query.charges.len());
         let mut mobilities = Vec::with_capacity(query.mobilities.len());
 
         for idx in 0..query.masses.len() {
-            let peak = (query.masses[idx], query.intensities[idx]);
+            let peak = (
+                query.masses[idx],
+                query.intensities[idx],
+                query.charges[idx],
+            );
             if !to_remove.contains(&peak) {
                 masses.push(query.masses[idx]);
                 intensities.push(query.intensities[idx]);
+                charges.push(query.charges[idx]);
                 if !query.mobilities.is_empty() {
                     mobilities.push(query.mobilities[idx]);
                 }
@@ -639,6 +650,7 @@ impl<'db> Scorer<'db> {
 
         query.masses = masses;
         query.intensities = intensities;
+        query.charges = charges;
         query.mobilities = mobilities;
         query.total_ion_current = query.intensities.iter().sum::<f32>();
     }
@@ -715,12 +727,13 @@ impl<'db> Scorer<'db> {
                 ) {
                     let peak_mass = query.masses[peak_idx];
                     let peak_intensity = query.intensities[peak_idx];
+                    let fragment_charge = query.charges[peak_idx].max(charge);
 
                     score.ppm_difference +=
                         peak_intensity * (mz - peak_mass).abs() * 2E6 / (mz + peak_mass);
 
-                    let exp_mz = peak_mass + PROTON;
-                    let calc_mz = mz + PROTON;
+                    let exp_mz = query.peak_mz(peak_idx);
+                    let calc_mz = frag.monoisotopic_mass / fragment_charge as f32 + PROTON;
 
                     match frag.kind {
                         Kind::A | Kind::B | Kind::C => {
@@ -743,7 +756,7 @@ impl<'db> Scorer<'db> {
                             }
                         };
                         fragments_details.kinds.push(frag.kind);
-                        fragments_details.charges.push(charge as i32);
+                        fragments_details.charges.push(fragment_charge as i32);
                         fragments_details.mz_experimental.push(exp_mz);
                         fragments_details.mz_calculated.push(calc_mz);
                         fragments_details.fragment_ordinals.push(idx);

--- a/crates/sage/src/spectrum.rs
+++ b/crates/sage/src/spectrum.rs
@@ -1,29 +1,6 @@
 use crate::database::binary_search_slice;
 use crate::mass::{Tolerance, NEUTRON, PROTON};
 
-/// A charge-less peak at monoisotopic mass
-#[derive(PartialEq, Copy, Clone, Default, Debug)]
-pub struct Peak {
-    pub intensity: f32,
-    pub mass: f32,
-}
-
-impl Eq for Peak {}
-
-impl PartialOrd for Peak {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for Peak {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.intensity
-            .total_cmp(&other.intensity)
-            .then_with(|| self.mass.total_cmp(&other.mass))
-    }
-}
-
 /// A de-isotoped peak, that might have some charge state information
 #[derive(PartialEq, PartialOrd, Debug, Copy, Clone)]
 pub struct Deisotoped {
@@ -72,6 +49,8 @@ pub struct ProcessedSpectrum {
     pub masses: Vec<f32>,
     /// MS peak intensities, parallel to `masses`
     pub intensities: Vec<f32>,
+    /// MS peak charges, parallel to `masses`
+    pub charges: Vec<u8>,
     /// Ion mobility values, parallel to `masses` for IMS spectra and empty otherwise
     pub mobilities: Vec<f32>,
     /// Total ion current
@@ -238,6 +217,98 @@ pub fn path_compression(peaks: &mut [Deisotoped]) {
     }
 }
 
+fn retain_top_n_by_intensity(
+    indices: &mut Vec<usize>,
+    masses: &[f32],
+    intensities: &[f32],
+    n: usize,
+    prefer_low_mass: bool,
+) {
+    debug_assert_eq!(masses.len(), intensities.len());
+    if n == 0 {
+        indices.clear();
+        return;
+    }
+
+    if indices.len() <= n {
+        return;
+    }
+
+    let keep_from = indices.len() - n;
+    indices.select_nth_unstable_by(keep_from, |&a, &b| {
+        intensities[a].total_cmp(&intensities[b]).then_with(|| {
+            if prefer_low_mass {
+                masses[b].total_cmp(&masses[a])
+            } else {
+                masses[a].total_cmp(&masses[b])
+            }
+        })
+    });
+    indices.drain(..keep_from);
+}
+
+fn select_columns(
+    indices: Vec<usize>,
+    masses: &[f32],
+    intensities: &[f32],
+    charges: &[u8],
+) -> (Vec<f32>, Vec<f32>, Vec<u8>) {
+    debug_assert_eq!(masses.len(), intensities.len());
+    debug_assert_eq!(masses.len(), charges.len());
+
+    let mut selected_masses = Vec::with_capacity(indices.len());
+    let mut selected_intensities = Vec::with_capacity(indices.len());
+    let mut selected_charges = Vec::with_capacity(indices.len());
+
+    for idx in indices {
+        selected_masses.push(masses[idx]);
+        selected_intensities.push(intensities[idx]);
+        selected_charges.push(charges[idx]);
+    }
+
+    (selected_masses, selected_intensities, selected_charges)
+}
+
+fn sort_columns_by_mass(
+    masses: Vec<f32>,
+    intensities: Vec<f32>,
+    charges: Vec<u8>,
+    mobilities: Vec<f32>,
+) -> (Vec<f32>, Vec<f32>, Vec<u8>, Vec<f32>) {
+    debug_assert_eq!(masses.len(), intensities.len());
+    debug_assert_eq!(masses.len(), charges.len());
+    debug_assert!(mobilities.is_empty() || mobilities.len() == masses.len());
+
+    if masses.len() <= 1 {
+        return (masses, intensities, charges, mobilities);
+    }
+
+    let has_mobility = !mobilities.is_empty();
+    let mut order = (0..masses.len()).collect::<Vec<_>>();
+    order.sort_by(|&a, &b| masses[a].total_cmp(&masses[b]));
+
+    let mut sorted_masses = Vec::with_capacity(masses.len());
+    let mut sorted_intensities = Vec::with_capacity(intensities.len());
+    let mut sorted_charges = Vec::with_capacity(charges.len());
+    let mut sorted_mobilities = Vec::with_capacity(mobilities.len());
+
+    for idx in order {
+        sorted_masses.push(masses[idx]);
+        sorted_intensities.push(intensities[idx]);
+        sorted_charges.push(charges[idx]);
+        if has_mobility {
+            sorted_mobilities.push(mobilities[idx]);
+        }
+    }
+
+    (
+        sorted_masses,
+        sorted_intensities,
+        sorted_charges,
+        sorted_mobilities,
+    )
+}
+
 impl ProcessedSpectrum {
     pub fn len(&self) -> usize {
         self.masses.len()
@@ -245,6 +316,10 @@ impl ProcessedSpectrum {
 
     pub fn is_empty(&self) -> bool {
         self.masses.is_empty()
+    }
+
+    pub fn peak_mz(&self, idx: usize) -> f32 {
+        self.masses[idx] / self.charges[idx] as f32 + PROTON
     }
 
     pub fn extract_ms1_precursor(&self) -> Option<(f32, u8)> {
@@ -276,7 +351,11 @@ impl SpectrumProcessor {
         }
     }
 
-    fn process_ms2(&self, should_deisotope: bool, spectrum: &RawSpectrum) -> Vec<Peak> {
+    fn process_ms2(
+        &self,
+        should_deisotope: bool,
+        spectrum: &RawSpectrum,
+    ) -> (Vec<f32>, Vec<f32>, Vec<u8>) {
         if spectrum.representation != Representation::Centroid {
             // Panic, because there's really nothing we can do with profile data
             panic!(
@@ -293,45 +372,49 @@ impl SpectrumProcessor {
             .unwrap_or(3);
 
         if should_deisotope {
-            let mut peaks = deisotope(
+            let peaks = deisotope(
                 &spectrum.mz,
                 &spectrum.intensity,
                 charge,
                 10.0,
                 self.min_deisotope_mz,
             );
-            peaks.sort_unstable_by(|a, b| {
-                b.intensity
-                    .total_cmp(&a.intensity)
-                    .then_with(|| a.mz.total_cmp(&b.mz))
-            });
+            let mz = peaks.iter().map(|peak| peak.mz).collect::<Vec<_>>();
+            let intensities = peaks.iter().map(|peak| peak.intensity).collect::<Vec<_>>();
+            let charges = peaks
+                .iter()
+                .map(|peak| peak.charge.unwrap_or(1))
+                .collect::<Vec<_>>();
+            let mut indices = peaks
+                .iter()
+                .enumerate()
+                .filter_map(|(idx, peak)| peak.envelope.is_none().then_some(idx))
+                .collect::<Vec<_>>();
 
-            peaks
-                .into_iter()
-                .filter(|peak| peak.envelope.is_none())
-                .map(|peak| {
-                    // Convert from MH* to M
-                    let mass = (peak.mz - PROTON) * peak.charge.unwrap_or(1) as f32;
-                    Peak {
-                        mass,
-                        intensity: peak.intensity,
-                    }
-                })
-                .take(self.take_top_n)
-                .collect::<Vec<Peak>>()
+            retain_top_n_by_intensity(&mut indices, &mz, &intensities, self.take_top_n, true);
+
+            let mut masses = Vec::with_capacity(indices.len());
+            let mut selected_intensities = Vec::with_capacity(indices.len());
+            let mut selected_charges = Vec::with_capacity(indices.len());
+            for idx in indices {
+                let charge = charges[idx];
+                masses.push((mz[idx] - PROTON) * charge as f32);
+                selected_intensities.push(intensities[idx]);
+                selected_charges.push(charge);
+            }
+
+            (masses, selected_intensities, selected_charges)
         } else {
-            let mut peaks = spectrum
+            let masses = spectrum
                 .mz
                 .iter()
-                .zip(spectrum.intensity.iter())
-                .map(|(mz, &intensity)| {
-                    let mass = (mz - PROTON) * 1.0;
-                    Peak { mass, intensity }
-                })
+                .map(|mz| (mz - PROTON) * 1.0)
                 .collect::<Vec<_>>();
-            crate::heap::bounded_min_heapify(&mut peaks, self.take_top_n);
-            peaks.truncate(self.take_top_n);
-            peaks
+            let intensities = spectrum.intensity.clone();
+            let charges = vec![1; masses.len()];
+            let mut indices = (0..masses.len()).collect::<Vec<_>>();
+            retain_top_n_by_intensity(&mut indices, &masses, &intensities, self.take_top_n, false);
+            select_columns(indices, &masses, &intensities, &charges)
         }
     }
 
@@ -341,60 +424,35 @@ impl SpectrumProcessor {
             debug_assert_eq!(spectrum.mz.len(), mobilities.len());
         }
 
-        if spectrum.ms_level == 1 && spectrum.mobility.is_some() {
-            let raw_mobilities = spectrum.mobility.as_ref().expect("checked above");
-            let mut peaks = spectrum
-                .mz
-                .iter()
-                .zip(spectrum.intensity.iter().zip(raw_mobilities.iter()))
-                .map(|(&mass, (&intensity, &mobility))| (mass - PROTON, intensity, mobility))
-                .collect::<Vec<_>>();
-
-            peaks.sort_by(|a, b| a.0.total_cmp(&b.0));
-
-            let mut masses = Vec::with_capacity(peaks.len());
-            let mut intensities = Vec::with_capacity(peaks.len());
-            let mut mobilities = Vec::with_capacity(peaks.len());
-            for (mass, intensity, mobility) in peaks {
-                masses.push(mass);
-                intensities.push(intensity);
-                mobilities.push(mobility);
-            }
-
-            let total_ion_current = intensities.iter().sum::<f32>();
-
-            return ProcessedSpectrum {
-                level: spectrum.ms_level,
-                id: spectrum.id,
-                file_id: spectrum.file_id,
-                scan_start_time: spectrum.scan_start_time,
-                ion_injection_time: spectrum.ion_injection_time,
-                precursors: spectrum.precursors,
-                masses,
-                intensities,
-                mobilities,
-                total_ion_current,
+        let (masses, intensities, charges, mobilities) =
+            if spectrum.ms_level == 1 && spectrum.mobility.is_some() {
+                let raw_mobilities = spectrum.mobility.as_ref().expect("checked above");
+                let masses = spectrum
+                    .mz
+                    .iter()
+                    .map(|mass| mass - PROTON)
+                    .collect::<Vec<_>>();
+                let intensities = spectrum.intensity.clone();
+                let charges = vec![1; masses.len()];
+                let mobilities = raw_mobilities.clone();
+                sort_columns_by_mass(masses, intensities, charges, mobilities)
+            } else {
+                let (masses, intensities, charges) = match spectrum.ms_level {
+                    2 => self.process_ms2(self.deisotope, &spectrum),
+                    _ => {
+                        let masses = spectrum
+                            .mz
+                            .iter()
+                            .map(|mass| (mass - PROTON) * 1.0)
+                            .collect::<Vec<_>>();
+                        let intensities = spectrum.intensity.clone();
+                        let charges = vec![1; masses.len()];
+                        (masses, intensities, charges)
+                    }
+                };
+                sort_columns_by_mass(masses, intensities, charges, Vec::new())
             };
-        }
 
-        let mut peaks = match spectrum.ms_level {
-            2 => self.process_ms2(self.deisotope, &spectrum),
-            _ => spectrum
-                .mz
-                .iter()
-                .zip(spectrum.intensity.iter())
-                .map(|(&mass, &intensity)| {
-                    let mass = (mass - PROTON) * 1.0;
-                    Peak { mass, intensity }
-                })
-                .collect::<Vec<_>>(),
-        };
-
-        peaks.sort_by(|a, b| a.mass.total_cmp(&b.mass));
-        let (masses, intensities): (Vec<_>, Vec<_>) = peaks
-            .into_iter()
-            .map(|peak| (peak.mass, peak.intensity))
-            .unzip();
         let total_ion_current = intensities.iter().sum::<f32>();
 
         ProcessedSpectrum {
@@ -406,7 +464,8 @@ impl SpectrumProcessor {
             precursors: spectrum.precursors,
             masses,
             intensities,
-            mobilities: Vec::new(),
+            charges,
+            mobilities,
             total_ion_current,
         }
     }
@@ -622,6 +681,7 @@ mod test {
             vec![100.0 - PROTON, 101.0 - PROTON, 102.0 - PROTON]
         );
         assert_eq!(processed.intensities, vec![10.0, 20.0, 30.0]);
+        assert_eq!(processed.charges, vec![1, 1, 1]);
         assert!(processed.mobilities.is_empty());
         assert_eq!(processed.total_ion_current, 60.0);
     }
@@ -644,8 +704,52 @@ mod test {
             vec![100.0 - PROTON, 101.0 - PROTON, 102.0 - PROTON]
         );
         assert_eq!(processed.intensities, vec![10.0, 20.0, 30.0]);
+        assert_eq!(processed.charges, vec![1, 1, 1]);
         assert_eq!(processed.mobilities, vec![1.0, 2.0, 3.0]);
         assert_eq!(processed.masses.len(), processed.intensities.len());
+        assert_eq!(processed.masses.len(), processed.charges.len());
         assert_eq!(processed.masses.len(), processed.mobilities.len());
+    }
+
+    #[test]
+    fn process_ms2_without_deisotoping_defaults_charges_to_one() {
+        let processor = SpectrumProcessor::new(10, false, 0.0);
+        let spectrum = RawSpectrum {
+            ms_level: 2,
+            representation: Representation::Centroid,
+            mz: vec![102.0, 100.0, 101.0],
+            intensity: vec![30.0, 10.0, 20.0],
+            ..RawSpectrum::default_with_file_id(7)
+        };
+
+        let processed = processor.process(spectrum);
+
+        assert_eq!(
+            processed.masses,
+            vec![100.0 - PROTON, 101.0 - PROTON, 102.0 - PROTON]
+        );
+        assert_eq!(processed.intensities, vec![10.0, 20.0, 30.0]);
+        assert_eq!(processed.charges, vec![1, 1, 1]);
+        assert_eq!(processed.peak_mz(1), 101.0);
+    }
+
+    #[test]
+    fn process_ms2_with_deisotoping_tracks_reassigned_charge() {
+        let processor = SpectrumProcessor::new(10, true, 0.0);
+        let spectrum = RawSpectrum {
+            ms_level: 2,
+            representation: Representation::Centroid,
+            mz: vec![812.0, 812.0 + NEUTRON / 2.0],
+            intensity: vec![9.0, 4.5],
+            ..RawSpectrum::default_with_file_id(7)
+        };
+
+        let processed = processor.process(spectrum);
+
+        assert_eq!(processed.masses.len(), 1);
+        assert_eq!(processed.intensities, vec![13.5]);
+        assert_eq!(processed.charges, vec![2]);
+        assert!((processed.masses[0] - (812.0 - PROTON) * 2.0).abs() < 0.001);
+        assert!((processed.peak_mz(0) - 812.0).abs() < 0.001);
     }
 }

--- a/crates/sage/src/tmt.rs
+++ b/crates/sage/src/tmt.rs
@@ -1,12 +1,8 @@
 //! TMT quantification
 #![allow(clippy::excessive_precision)]
-#![allow(unused_imports)]
-use crate::database::binary_search_slice;
-use crate::ion_series::{IonSeries, Kind};
-use crate::mass::{Tolerance, H2O, NH3, PROTON};
-use crate::peptide::Peptide;
-use crate::scoring::{Feature, Scorer};
-use crate::spectrum::{self, Peak, Precursor, ProcessedSpectrum};
+use crate::mass::{Tolerance, PROTON};
+use crate::scoring::Feature;
+use crate::spectrum::{self, ProcessedSpectrum};
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 
@@ -67,108 +63,6 @@ pub struct Purity {
     pub correct_precursors: usize,
     pub incorrect_precursors: usize,
 }
-
-/// Calculate SPS purity stats - which SPS precursor ions actually correspond
-/// to theoretical b/y ions, and percentage of total SPS precursor MS2 intensity
-/// that is explained by theoretical b/y ions
-// fn purity_of_match(
-//     precursors: &[Precursor],
-//     ms2: &ProcessedSpectrum,
-//     theoretical_peaks: &[Peak],
-//     max_charge: u8,
-//     fragment_tolerance: Tolerance,
-// ) -> Purity {
-//     let mut explained_intensity = 0.0;
-//     let mut interference = 0.0;
-//     let mut correct_precursors = 0;
-//     let mut incorrect_precursors = 0;
-
-//     for precursor in precursors {
-//         // Spurious SPS precursor introduced by MSConvert
-//         // https://github.com/ProteoWizard/pwiz/issues/2202
-//         if precursor.scan.unwrap_or(0) != ms2.scan {
-//             continue;
-//         }
-
-//         // This is really a m/z window, we haven't performed charge state deconvolution!
-//         // Select a window of MS2 peaks that have been sampled for MS3
-//         let isolation_tolerance = precursor
-//             .isolation_window
-//             .unwrap_or_else(|| Tolerance::Da(-0.5, 0.5));
-//         let isolation_window = isolation_tolerance.bounds(precursor.mz - PROTON);
-
-//         let (idx_lo, idx_hi) = binary_search_slice(
-//             &ms2.peaks,
-//             |peak, key| peak.mass.total_cmp(key),
-//             isolation_window.0,
-//             isolation_window.1,
-//         );
-
-//         // Create slice surrounding SPS peaks selected
-//         let window = &ms2.peaks[idx_lo..idx_hi];
-//         interference += window
-//             .iter()
-//             .filter(|peak| peak.mass >= isolation_window.0 && peak.mass <= isolation_window.1)
-//             .map(|peak| peak.intensity)
-//             .sum::<f32>();
-
-//         // Pick the most intense peak within the isolation window, and decide whether it is
-//         // assignable to the best candidate peptide
-//         let assigned_to_candidate = if let Some(best_peak) =
-//             spectrum::select_closest_peak(window, precursor.mz - PROTON, isolation_tolerance)
-//         {
-//             let mut correct = false;
-//             'outer: for charge in 1..max_charge {
-//                 for loss in [0.0, NH3, H2O] {
-//                     let mass = best_peak.mass * charge as f32 + loss;
-//                     if spectrum::select_closest_peak(theoretical_peaks, mass, fragment_tolerance)
-//                         .is_some()
-//                     {
-//                         correct = true;
-//                         interference -= best_peak.intensity;
-//                         explained_intensity += best_peak.intensity;
-
-//                         break 'outer;
-//                     }
-//                 }
-//             }
-//             correct
-//         } else {
-//             false
-//         };
-
-//         if assigned_to_candidate {
-//             correct_precursors += 1;
-//         } else {
-//             incorrect_precursors += 1;
-//         }
-//     }
-
-//     Purity {
-//         ratio: explained_intensity / (explained_intensity + interference),
-//         correct_precursors,
-//         incorrect_precursors,
-//     }
-// }
-
-// fn mk_theoretical(peptide: &Peptide) -> Vec<Peak> {
-//     let mut theoretical_peaks = IonSeries::new(peptide, Kind::B)
-//         .map(|ion| Peak {
-//             mass: ion.monoisotopic_mass,
-//             intensity: 0.0,
-//         })
-//         .collect::<Vec<_>>();
-
-//     if let Some(crate::mass::Residue::Mod('K', _)) = peptide.sequence.last() {
-//         theoretical_peaks.extend(IonSeries::new(peptide, Kind::Y).map(|ion| Peak {
-//             mass: ion.monoisotopic_mass,
-//             intensity: 0.0,
-//         }));
-//     }
-
-//     theoretical_peaks.sort_unstable_by(|a, b| a.mass.total_cmp(&b.mass));
-//     theoretical_peaks
-// }
 
 #[derive(Debug)]
 pub struct Quant<'ms3> {


### PR DESCRIPTION
 Tracks charge state per ion in ProcessedSpectrum as a SoA charges: Vec<u8> column (#220)

- Preserves reassigned charge state for deisotoped MS2 peaks (otherwise defaults to 1)
- Removes the transient spectrum::Peak AoS helper
- Updates matched fragment annotation so fragment_charge, calculated m/z, and experimental m/z reflect the observed/deisotoped peak charge