### PR TITLE
Support per-mod variable modification limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Per-modification occurrence limits using `{"mass": <mass>, "max_count": <limit>}` entries in `database.variable_mods`; existing bare-mass entries remain supported.
+- `database.max_combinations` to cap the number of peptide variants (including the unmodified form) generated from variable modifications, preferring variants with fewer modifications.
+
 ## [v0.15.0]
 ### Added
 - IDPicker-based protein grouping with picked group FDR control (`protein_grouping` setting, enabled by default). Proteins are grouped using a bipartite graph greedy set cover approach, and protein group-level q-values are reported via target-decoy competition. New output columns: `protein_groups`, `num_protein_groups`, `protein_group_q`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2671,6 +2671,7 @@ dependencies = [
  "rayon",
  "regex",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/DOCS.md
+++ b/DOCS.md
@@ -173,15 +173,17 @@ For additional information about configuration options and output file formats, 
       "K": 304.207,         // Apply static modification to lysine
       "C": 57.0215          // Apply static modification to cysteine
     },
-    "variable_mods": {    // Optional[Dict[char, float]] {default={}}, variable modifications
+    "variable_mods": {    // Variable modification masses or objects with mass and optional max_count
       "M": [15.9949],     // Variable mods are applied *before* static mod
+      "K": [{"mass": 42.0106, "max_count": 1}, 14.0157],
       "^Q": [-17.026549],
       "^E": [-18.010565], // Applied to N-terminal glutamic acid
       "$": [49.2, 22.9],  // Applied to peptide C-terminus
       "[": [42.0],          // Applied to protein N-terminus
       "]": [111.0]          // Applied to protein C-terminus
-    }
-    "max_variable_mods": 2, // Optional[int] {default=2} Limit k-combinations of variable modifications
+    },
+    "max_variable_mods": 2, // Optional[int] {default=2} Limit modifications on each peptide
+    "max_combinations": 8,  // Optional[int] {default=null} Limit total variants per peptide
     "decoy_tag": "rev_",    // Optional[str] {default="rev_"}: See notes above
     "generate_decoys": false, // Optional[bool] {default="true"}: Ignore decoys in FASTA database matching `decoy_tag`
     "fasta": "dual.fasta"   // str: mandatory path to FASTA file
@@ -322,13 +324,15 @@ Example:
 
 #### Variable Modifications
 
-- **max_variable_mods**: Integer. Limit k-combinations of variable modifications (default: 2).
-- **variable_mods**: Dictionary with characters as keys and list of floats (or single floats) as values. Represents variable modifications applied to amino acids or termini (default: {}).
+- **max_variable_mods**: Integer. Limit the total variable modifications on each peptide (default: 2).
+- **max_combinations**: Integer. Optional hard cap on the total variants generated per input peptide, including the unmodified form. Variants with fewer modifications are retained first. Values below 1 are treated as 1 (default: unlimited).
+- **variable_mods**: Dictionary with characters as keys and lists containing bare masses or objects with a `mass` field and optional `max_count`. A bare mass remains unrestricted except by `max_variable_mods`; `max_count` limits occurrences of that specific modification on one peptide.
   - Example: Apply a variable modification of 15.9949 to methionine, 49.2022 to the C-terminus of the peptide, 42.0 to the N-terminus of the protein, and 111.0 to the C-terminus of the protein.
     ```jsonc
     "database": {
       "variable_mods": {
-        "M": [15.9949], 
+        "M": [15.9949],
+        "K": [{"mass": 42.0106, "max_count": 1}, 14.0157],
         "^Q": [-17.026549],
         "^E": [-18.010565], // Applied to N-terminal glutamic acid
         "$": [49.2022],     // Applied to peptide C-terminus

--- a/crates/sage/Cargo.toml
+++ b/crates/sage/Cargo.toml
@@ -22,4 +22,4 @@ serde = { version="1.0", features = ["derive"] }
 [dev-dependencies]
 quickcheck = "1"
 quickcheck_macros = "1"
-
+serde_json = "1.0"

--- a/crates/sage/src/database.rs
+++ b/crates/sage/src/database.rs
@@ -2,7 +2,7 @@ use crate::enzyme::{group_digests, Enzyme, EnzymeParameters};
 use crate::fasta::Fasta;
 use crate::ion_series::{IonSeries, Kind};
 use crate::mass::Tolerance;
-use crate::modification::{validate_mods, validate_var_mods, ModificationSpecificity};
+use crate::modification::{validate_mods, validate_var_mods, ModificationSpecificity, VarModEntry};
 use crate::peptide::Peptide;
 use dashmap::DashSet;
 use fnv::FnvBuildHasher;
@@ -74,10 +74,16 @@ pub struct Builder {
     pub min_ion_index: Option<usize>,
     /// Static modifications to add to matching amino acids
     pub static_mods: Option<HashMap<String, f32>>,
-    /// Variable modifications to add to matching amino acids
-    pub variable_mods: Option<HashMap<String, Vec<f32>>>,
+    /// Variable modifications to add to matching amino acids.
+    /// Each entry is either a bare mass (`15.9949`) or an object with `mass` and
+    /// optional `max_count` fields (`{"mass": 15.9949, "max_count": 1}`).
+    pub variable_mods: Option<HashMap<String, Vec<VarModEntry>>>,
     /// Limit number of variable modifications on a peptide
     pub max_variable_mods: Option<usize>,
+    /// Hard cap on the total peptide variants generated per input peptide,
+    /// including its unmodified form. Values below 1 are normalized to 1.
+    /// Variants with fewer PTMs are preferred (generated first).
+    pub max_combinations: Option<usize>,
     /// Use this prefix for decoy proteins
     pub decoy_tag: Option<String>,
 
@@ -106,6 +112,7 @@ impl Builder {
             static_mods: validate_mods(self.static_mods),
             variable_mods: validate_var_mods(self.variable_mods),
             max_variable_mods: self.max_variable_mods.map(|x| x.max(1)).unwrap_or(2),
+            max_combinations: self.max_combinations.map(|x| x.max(1)),
             generate_decoys: self.generate_decoys.unwrap_or(true),
             fasta: self.fasta.expect("A fasta file must be provided!"),
             prefilter_chunk_size: self.prefilter_chunk_size.unwrap_or(0),
@@ -128,8 +135,9 @@ pub struct Parameters {
     pub ion_kinds: Vec<Kind>,
     pub min_ion_index: usize,
     pub static_mods: HashMap<ModificationSpecificity, f32>,
-    pub variable_mods: HashMap<ModificationSpecificity, Vec<f32>>,
+    pub variable_mods: HashMap<ModificationSpecificity, Vec<VarModEntry>>,
     pub max_variable_mods: usize,
+    pub max_combinations: Option<usize>,
     pub decoy_tag: String,
     pub generate_decoys: bool,
     pub fasta: String,
@@ -139,21 +147,48 @@ pub struct Parameters {
 }
 
 impl Parameters {
+    /// Flatten variable modifications into a stable order. This matters when
+    /// `max_combinations` truncates variants: equivalent configurations must
+    /// retain the same variants regardless of randomized `HashMap` iteration.
+    fn variable_modifications(&self) -> Vec<(ModificationSpecificity, f32, Option<usize>)> {
+        let mut mods = self
+            .variable_mods
+            .iter()
+            .flat_map(|(specificity, entries)| {
+                entries.iter().enumerate().map(|(entry_order, entry)| {
+                    (*specificity, entry_order, entry.mass(), entry.max_count())
+                })
+            })
+            .collect::<Vec<_>>();
+        mods.sort_unstable_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
+        mods.into_iter()
+            .map(|(specificity, _, mass, max_count)| (specificity, mass, max_count))
+            .collect()
+    }
+
     pub fn auto_calculate_prefilter_chunk_size(&mut self, fasta: &Fasta) {
         const MAX_PEPS_PER_CHUNK: usize = 2usize.pow(23);
         self.prefilter_chunk_size = match self.prefilter_chunk_size {
             0 => {
                 let enzyme = self.enzyme.clone().into();
                 let total_unmodified_pep_count: usize = fasta.digest(&enzyme).len();
-                let mod_count_estimate =
-                    (self.variable_mods.len() + 1) * (1 << self.max_variable_mods);
-                let chunk_count =
-                    mod_count_estimate * total_unmodified_pep_count / MAX_PEPS_PER_CHUNK;
-                if chunk_count == 0 {
-                    fasta.targets.len()
+                let combination_factor = if self.max_variable_mods >= usize::BITS as usize {
+                    usize::MAX
                 } else {
-                    fasta.targets.len() / chunk_count
+                    1usize << self.max_variable_mods
+                };
+                let mut mod_count_estimate =
+                    (self.variable_mods.len() + 1).saturating_mul(combination_factor);
+                if let Some(max_combinations) = self.max_combinations {
+                    mod_count_estimate = mod_count_estimate.min(max_combinations);
                 }
+                let chunk_count = mod_count_estimate.saturating_mul(total_unmodified_pep_count)
+                    / MAX_PEPS_PER_CHUNK;
+                fasta
+                    .targets
+                    .len()
+                    .checked_div(chunk_count)
+                    .unwrap_or(fasta.targets.len())
             }
             x => x,
         };
@@ -175,11 +210,7 @@ impl Parameters {
             digests.len()
         );
 
-        let mods = self
-            .variable_mods
-            .iter()
-            .flat_map(|(a, b)| b.iter().map(|b| (*a, *b)))
-            .collect::<Vec<_>>();
+        let mods = self.variable_modifications();
 
         let targets: DashSet<_, FnvBuildHasher> = DashSet::default();
         digests
@@ -196,7 +227,12 @@ impl Parameters {
             .filter_map(Result::ok)
             .flat_map_iter(|peptide| {
                 peptide
-                    .apply(&mods, &self.static_mods, self.max_variable_mods)
+                    .apply(
+                        &mods,
+                        &self.static_mods,
+                        self.max_variable_mods,
+                        self.max_combinations,
+                    )
                     .into_iter()
                     .filter(|peptide| {
                         peptide.monoisotopic >= self.peptide_min_mass
@@ -348,7 +384,9 @@ impl Parameters {
         let potential_mods = self
             .variable_mods
             .iter()
-            .flat_map(|(a, b)| b.iter().map(|b| (*a, *b)))
+            .flat_map(|(specificity, entries)| {
+                entries.iter().map(|entry| (*specificity, entry.mass()))
+            })
             .collect::<Vec<(ModificationSpecificity, f32)>>();
 
         IndexedDatabase {
@@ -593,6 +631,47 @@ mod test {
     }
 
     #[test]
+    fn structured_variable_mod_config_round_trips() {
+        let builder: Builder = serde_json::from_value(serde_json::json!({
+            "fasta": "none",
+            "variable_mods": {
+                "M": [15.9949],
+                "K": [
+                    {"mass": 42.0106, "max_count": 1},
+                    {"mass": 14.0157}
+                ]
+            },
+            "max_variable_mods": 2,
+            "max_combinations": 0
+        }))
+        .unwrap();
+
+        let params = builder.make_parameters();
+        assert_eq!(params.max_variable_mods, 2);
+        assert_eq!(params.max_combinations, Some(1));
+
+        let mods = params.variable_modifications();
+        assert_eq!(mods.len(), 3);
+        assert_eq!(mods[0].0, ModificationSpecificity::Residue(b'K'));
+        assert!((mods[0].1 - 42.0106).abs() < 1e-4);
+        assert_eq!(mods[0].2, Some(1));
+        assert_eq!(mods[1].0, ModificationSpecificity::Residue(b'K'));
+        assert!((mods[1].1 - 14.0157).abs() < 1e-4);
+        assert_eq!(mods[1].2, None);
+        assert_eq!(mods[2].0, ModificationSpecificity::Residue(b'M'));
+        assert!((mods[2].1 - 15.9949).abs() < 1e-4);
+        assert_eq!(mods[2].2, None);
+
+        let serialized = serde_json::to_value(params).unwrap();
+        let k_entries = &serialized["variable_mods"]["K"];
+        assert!(k_entries[0].is_object());
+        assert_eq!(k_entries[0]["max_count"], 1);
+        assert!(k_entries[1].is_object());
+        assert!(k_entries[1].get("max_count").is_none());
+        assert!(serialized["variable_mods"]["M"][0].is_number());
+    }
+
+    #[test]
     fn digestion() {
         let fasta = r#"
         >sp|AAAAA
@@ -631,10 +710,14 @@ mod test {
             ion_kinds: vec![Kind::B, Kind::Y],
             min_ion_index: 2,
             static_mods: HashMap::default(),
-            variable_mods: [(ModificationSpecificity::ProteinN(None), vec![42.0])]
-                .into_iter()
-                .collect(),
+            variable_mods: [(
+                ModificationSpecificity::ProteinN(None),
+                vec![VarModEntry::Mass(42.0)],
+            )]
+            .into_iter()
+            .collect(),
             max_variable_mods: 2,
+            max_combinations: None,
             decoy_tag: "rev_".into(),
             generate_decoys: false,
             fasta: "none".into(),

--- a/crates/sage/src/ion_series.rs
+++ b/crates/sage/src/ion_series.rs
@@ -257,7 +257,9 @@ mod test {
     #[test]
     fn nterm_mod() {
         let static_mods = [(ModificationSpecificity::PeptideN(None), 229.01)].into();
-        let peptide = peptide("PEPTIDE").apply(&[], &static_mods, 1).remove(0);
+        let peptide = peptide("PEPTIDE")
+            .apply(&[], &static_mods, 1, None)
+            .remove(0);
 
         // Charge state 1, b-ions should be TMT tagged
         let expected_b = [
@@ -279,7 +281,9 @@ mod test {
     #[test]
     fn cterm_mod() {
         let static_mods = [(ModificationSpecificity::PeptideC(None), 229.01)].into();
-        let peptide = peptide("PEPTIDE").apply(&[], &static_mods, 1).remove(0);
+        let peptide = peptide("PEPTIDE")
+            .apply(&[], &static_mods, 1, None)
+            .remove(0);
         assert!((peptide.monoisotopic - 1028.37).abs() < 0.001);
 
         // b-ions should not be tagged
@@ -303,7 +307,7 @@ mod test {
     fn internal_mod() {
         let peptide = peptide("PEPTIDE");
         let static_mods = [(ModificationSpecificity::Residue(b'I'), 29.0)].into();
-        let peptide = peptide.apply(&[], &static_mods, 1).remove(0);
+        let peptide = peptide.apply(&[], &static_mods, 1, None).remove(0);
 
         let expected_b = [
             98.06004,

--- a/crates/sage/src/modification.rs
+++ b/crates/sage/src/modification.rs
@@ -4,7 +4,113 @@ use std::{
     str::FromStr,
 };
 
-use serde::Serialize;
+use serde::{
+    de::{self, value::MapAccessDeserializer, MapAccess, Visitor},
+    Deserialize, Deserializer, Serialize,
+};
+
+/// A variable modification with optional per-peptide occurrence limit.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct VariableModification {
+    pub mass: f32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_count: Option<usize>,
+}
+
+/// A variable modification entry may use the existing bare-mass syntax or the
+/// extensible object syntax.
+#[derive(Clone, Debug, Serialize, PartialEq)]
+#[serde(untagged)]
+pub enum VarModEntry {
+    Mass(f32),
+    Detailed(VariableModification),
+}
+
+impl<'de> Deserialize<'de> for VarModEntry {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct VarModEntryVisitor;
+
+        impl VarModEntryVisitor {
+            fn mass<E>(value: f64) -> Result<VarModEntry, E>
+            where
+                E: de::Error,
+            {
+                if !value.is_finite() || value.abs() > f32::MAX as f64 {
+                    return Err(E::custom("variable modification mass is out of range"));
+                }
+                Ok(VarModEntry::Mass(value as f32))
+            }
+        }
+
+        impl<'de> Visitor<'de> for VarModEntryVisitor {
+            type Value = VarModEntry;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str(
+                    "a modification mass or an object containing mass and optional max_count",
+                )
+            }
+
+            fn visit_f64<E>(self, value: f64) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Self::mass(value)
+            }
+
+            fn visit_f32<E>(self, value: f32) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Self::mass(value as f64)
+            }
+
+            fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Self::mass(value as f64)
+            }
+
+            fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Self::mass(value as f64)
+            }
+
+            fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+            where
+                A: MapAccess<'de>,
+            {
+                VariableModification::deserialize(MapAccessDeserializer::new(map))
+                    .map(VarModEntry::Detailed)
+            }
+        }
+
+        deserializer.deserialize_any(VarModEntryVisitor)
+    }
+}
+
+impl VarModEntry {
+    pub fn mass(&self) -> f32 {
+        match self {
+            VarModEntry::Mass(m) => *m,
+            VarModEntry::Detailed(modification) => modification.mass,
+        }
+    }
+
+    pub fn max_count(&self) -> Option<usize> {
+        match self {
+            VarModEntry::Mass(_) => None,
+            VarModEntry::Detailed(modification) => modification.max_count,
+        }
+    }
+}
 
 use crate::mass::VALID_AA;
 
@@ -127,14 +233,14 @@ pub fn validate_mods(input: Option<HashMap<String, f32>>) -> HashMap<Modificatio
 }
 
 pub fn validate_var_mods(
-    input: Option<HashMap<String, Vec<f32>>>,
-) -> HashMap<ModificationSpecificity, Vec<f32>> {
+    input: Option<HashMap<String, Vec<VarModEntry>>>,
+) -> HashMap<ModificationSpecificity, Vec<VarModEntry>> {
     let mut output = HashMap::new();
     if let Some(input) = input {
-        for (s, mass) in input {
+        for (s, entries) in input {
             match ModificationSpecificity::from_str(&s) {
                 Ok(m) => {
-                    output.insert(m, mass);
+                    output.insert(m, entries);
                 }
                 Err(InvalidModification::Empty) => {
                     log::error!("Skipping invalid modification string: empty")
@@ -176,5 +282,109 @@ mod test {
             "Z".parse::<ModificationSpecificity>(),
             Err(InvalidResidue('Z'))
         );
+    }
+
+    #[test]
+    fn var_mod_entry_bare_mass() {
+        let entry = VarModEntry::Mass(15.9949);
+        assert_eq!(entry.mass(), 15.9949);
+        assert_eq!(entry.max_count(), None);
+    }
+
+    #[test]
+    fn var_mod_entry_detailed_with_limit() {
+        let entry = VarModEntry::Detailed(VariableModification {
+            mass: 15.9949,
+            max_count: Some(1),
+        });
+        assert_eq!(entry.mass(), 15.9949);
+        assert_eq!(entry.max_count(), Some(1));
+    }
+
+    #[test]
+    fn deserialize_var_mod_entries() {
+        let entries: Vec<VarModEntry> = serde_json::from_str(
+            r#"[15.9949, {"mass": 42.0106, "max_count": 1}, {"mass": 14.0157}]"#,
+        )
+        .unwrap();
+
+        assert_eq!(entries.len(), 3);
+        assert!((entries[0].mass() - 15.9949).abs() < 1e-4);
+        assert_eq!(entries[0].max_count(), None);
+        assert!((entries[1].mass() - 42.0106).abs() < 1e-4);
+        assert_eq!(entries[1].max_count(), Some(1));
+        assert!((entries[2].mass() - 14.0157).abs() < 1e-4);
+        assert_eq!(entries[2].max_count(), None);
+
+        let serialized = serde_json::to_value(&entries).unwrap();
+        assert!(serialized[0].is_number());
+        assert!(serialized[1].is_object());
+        assert_eq!(serialized[1]["max_count"], 1);
+        assert!(serialized[2].is_object());
+        assert!(serialized[2].get("max_count").is_none());
+
+        let round_tripped: Vec<VarModEntry> = serde_json::from_value(serialized).unwrap();
+        assert_eq!(entries, round_tripped);
+    }
+
+    #[test]
+    fn reject_unsupported_var_mod_shapes_and_fields() {
+        assert!(serde_json::from_str::<Vec<VarModEntry>>(r#"[[42.0106, 1]]"#).is_err());
+        assert!(serde_json::from_str::<Vec<VarModEntry>>(
+            r#"[{"mass": 42.0106, "max_count": 1, "name": "Acetyl"}]"#
+        )
+        .is_err());
+        assert!(serde_json::from_str::<Vec<VarModEntry>>(
+            r#"[{"mass": 42.0106, "max_counts": 1}]"#
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn validate_var_mods_mixed() {
+        use ModificationSpecificity::*;
+        // Mix bare masses and detailed entries
+        let mut raw = HashMap::new();
+        raw.insert(
+            "M".to_string(),
+            vec![
+                VarModEntry::Mass(15.9949),
+                VarModEntry::Detailed(VariableModification {
+                    mass: 15.9949,
+                    max_count: Some(1),
+                }),
+            ],
+        );
+        raw.insert(
+            "C".to_string(),
+            vec![VarModEntry::Detailed(VariableModification {
+                mass: 57.0215,
+                max_count: Some(2),
+            })],
+        );
+        let result = validate_var_mods(Some(raw));
+
+        let m_entries = result.get(&Residue(b'M')).unwrap();
+        assert_eq!(m_entries.len(), 2);
+        assert!((m_entries[0].mass() - 15.9949).abs() < 1e-4);
+        assert_eq!(m_entries[0].max_count(), None);
+        assert!((m_entries[1].mass() - 15.9949).abs() < 1e-4);
+        assert_eq!(m_entries[1].max_count(), Some(1));
+
+        let c_entries = result.get(&Residue(b'C')).unwrap();
+        assert_eq!(c_entries.len(), 1);
+        assert!((c_entries[0].mass() - 57.0215).abs() < 1e-4);
+        assert_eq!(c_entries[0].max_count(), Some(2));
+    }
+
+    #[test]
+    fn validate_var_mods_invalid_residue_skipped() {
+        let mut raw = HashMap::new();
+        raw.insert("Z".to_string(), vec![VarModEntry::Mass(15.9949)]);
+        raw.insert("M".to_string(), vec![VarModEntry::Mass(15.9949)]);
+        let result = validate_var_mods(Some(raw));
+        // Z is invalid — only M should survive
+        assert_eq!(result.len(), 1);
+        assert!(result.contains_key(&ModificationSpecificity::Residue(b'M')));
     }
 }

--- a/crates/sage/src/peptide.rs
+++ b/crates/sage/src/peptide.rs
@@ -153,33 +153,40 @@ impl Peptide {
         }
     }
 
-    fn push_resi(&self, acc: &mut Vec<(Site, f32)>, target: ModificationSpecificity, mass: f32) {
+    fn push_resi(
+        &self,
+        acc: &mut Vec<(Site, f32, usize)>,
+        target: ModificationSpecificity,
+        mass: f32,
+        mod_idx: usize,
+    ) {
         match (target, self.position) {
-            (ModificationSpecificity::PeptideN(None), _) => acc.push((Site::Nterm, mass)),
+            (ModificationSpecificity::PeptideN(None), _) => acc.push((Site::Nterm, mass, mod_idx)),
             (ModificationSpecificity::PeptideN(Some(resi)), _)
                 if resi == *self.sequence.first().unwrap_or(&0) =>
             {
-                acc.push((Site::Sequence(0), mass))
+                acc.push((Site::Sequence(0), mass, mod_idx))
             }
-            (ModificationSpecificity::PeptideC(None), _) => acc.push((Site::Cterm, mass)),
+            (ModificationSpecificity::PeptideC(None), _) => acc.push((Site::Cterm, mass, mod_idx)),
             (ModificationSpecificity::PeptideC(Some(resi)), _)
                 if resi == *self.sequence.last().unwrap_or(&0) =>
             {
                 acc.push((
                     Site::Sequence(self.sequence.len().saturating_sub(1) as u32),
                     mass,
+                    mod_idx,
                 ))
             }
             (ModificationSpecificity::ProteinN(None), Position::Nterm | Position::Full) => {
-                acc.push((Site::Nterm, mass))
+                acc.push((Site::Nterm, mass, mod_idx))
             }
             (ModificationSpecificity::ProteinN(Some(resi)), Position::Nterm | Position::Full)
                 if resi == *self.sequence.first().unwrap_or(&0) =>
             {
-                acc.push((Site::Sequence(0), mass))
+                acc.push((Site::Sequence(0), mass, mod_idx))
             }
             (ModificationSpecificity::ProteinC(None), Position::Cterm | Position::Full) => {
-                acc.push((Site::Cterm, mass))
+                acc.push((Site::Cterm, mass, mod_idx))
             }
             (ModificationSpecificity::ProteinC(Some(resi)), Position::Cterm | Position::Full)
                 if resi == *self.sequence.last().unwrap_or(&0) =>
@@ -187,6 +194,7 @@ impl Peptide {
                 acc.push((
                     Site::Sequence(self.sequence.len().saturating_sub(1) as u32),
                     mass,
+                    mod_idx,
                 ))
             }
             (ModificationSpecificity::Residue(resi), _) => {
@@ -196,7 +204,7 @@ impl Peptide {
                         .enumerate()
                         .filter_map(|(idx, residue)| {
                             if resi == *residue {
-                                Some((Site::Sequence(idx as u32), mass))
+                                Some((Site::Sequence(idx as u32), mass, mod_idx))
                             } else {
                                 None
                             }
@@ -254,12 +262,16 @@ impl Peptide {
         }
     }
 
-    /// Apply variable modifications, then static modifications to a peptide
+    /// Apply variable modifications, then static modifications to a peptide.
+    /// `variable_mods` entries are `(specificity, mass, per_mod_limit)`.
+    /// `max_combinations` caps total variants (unmodified + modified); fewer-PTM
+    /// variants are always generated first so they are preferred when truncating.
     pub fn apply(
         mut self,
-        variable_mods: &[(ModificationSpecificity, f32)],
+        variable_mods: &[(ModificationSpecificity, f32, Option<usize>)],
         static_mods: &HashMap<ModificationSpecificity, f32>,
         combinations: usize,
+        max_combinations: Option<usize>,
     ) -> Vec<Peptide> {
         if variable_mods.is_empty() {
             for (target, mass) in static_mods {
@@ -268,24 +280,50 @@ impl Peptide {
             self.monoisotopic += self.modification_mass();
             vec![self]
         } else {
-            let mut mods = Vec::new();
-            for (residue, mass) in variable_mods.iter() {
-                self.push_resi(&mut mods, *residue, *mass);
+            let mut mods: Vec<(Site, f32, usize)> = Vec::new();
+            for (mod_idx, (residue, mass, _limit)) in variable_mods.iter().enumerate() {
+                self.push_resi(&mut mods, *residue, *mass, mod_idx);
             }
 
             let mut modified = Vec::new();
             modified.push(self.clone());
+            let mut mod_counts = vec![0usize; variable_mods.len()];
+            let mut touched_mods = Vec::new();
 
-            for n in 1..=combinations {
+            'outer: for n in 1..=combinations {
                 'next: for combination in mods.iter().combinations(n).filter(no_duplicates) {
                     let mut set = FnvHashSet::default();
-                    for (site, _) in &combination {
+                    for (site, _, _) in &combination {
                         if !set.insert(*site) {
                             continue 'next;
                         }
                     }
+
+                    // Enforce per-mod count limits
+                    for (_, _, mod_idx) in &combination {
+                        if mod_counts[*mod_idx] == 0 {
+                            touched_mods.push(*mod_idx);
+                        }
+                        mod_counts[*mod_idx] += 1;
+                    }
+                    let exceeds_limit = touched_mods.iter().any(|&mod_idx| {
+                        variable_mods[mod_idx]
+                            .2
+                            .map_or(false, |limit| mod_counts[mod_idx] > limit)
+                    });
+                    for mod_idx in touched_mods.drain(..) {
+                        mod_counts[mod_idx] = 0;
+                    }
+                    if exceeds_limit {
+                        continue 'next;
+                    }
+
+                    if max_combinations.map_or(false, |cap| modified.len() >= cap) {
+                        break 'outer;
+                    }
+
                     let mut peptide = self.clone();
-                    for (site, mass) in combination {
+                    for (site, mass, _) in combination {
                         peptide.apply_site(*site, *mass);
                     }
                     modified.push(peptide);
@@ -318,10 +356,10 @@ impl Peptide {
     }
 }
 
-fn no_duplicates(combination: &Vec<&(Site, f32)>) -> bool {
+fn no_duplicates(combination: &Vec<&(Site, f32, usize)>) -> bool {
     let mut n = 0;
     let mut c = 0;
-    for (site, _) in combination {
+    for (site, _, _) in combination {
         match site {
             Site::Nterm => n += 1,
             Site::Cterm => c += 1,
@@ -418,9 +456,11 @@ mod test {
         combo: usize,
     ) -> Vec<String> {
         let static_mods = HashMap::default();
+        let mods_with_limits: Vec<(ModificationSpecificity, f32, Option<usize>)> =
+            mods.iter().map(|&(s, m)| (s, m, None)).collect();
         peptide
             .clone()
-            .apply(&mods, &static_mods, combo)
+            .apply(&mods_with_limits, &static_mods, combo, None)
             .into_iter()
             .map(|p| p.to_string())
             .collect::<Vec<_>>()
@@ -664,15 +704,64 @@ mod test {
         let mut static_mods = HashMap::new();
         static_mods.insert(Residue(b'C'), 57.0);
 
-        let variable_mods = [(Residue(b'C'), 30.0)];
+        let variable_mods = [(Residue(b'C'), 30.0, None)];
 
         let peptides = peptide
-            .apply(&variable_mods, &static_mods, 2)
+            .apply(&variable_mods, &static_mods, 2, None)
             .into_iter()
             .map(|p| p.to_string())
             .collect::<Vec<_>>();
 
         assert_eq!(peptides, expected);
+    }
+
+    #[test]
+    fn test_per_mod_limit() {
+        use ModificationSpecificity::*;
+        // GCMGCMG has two M residues; limit oxidation to max 1 per peptide
+        let variable_mods = [(Residue(b'M'), 16.0f32, Some(1))];
+        let peptide = Peptide::try_from(Digest {
+            sequence: "GCMGCMG".into(),
+            ..Default::default()
+        })
+        .unwrap();
+
+        let static_mods = HashMap::default();
+        let peptides: Vec<String> = peptide
+            .clone()
+            .apply(&variable_mods, &static_mods, 2, None)
+            .into_iter()
+            .map(|p| p.to_string())
+            .collect();
+
+        // Should get unmodified + each single-M variant, but NOT the double-M variant
+        let expected = vec!["GCMGCMG", "GCM[+16]GCMG", "GCMGCM[+16]G"];
+        assert_eq!(peptides, expected);
+    }
+
+    #[test]
+    fn test_max_combinations() {
+        use ModificationSpecificity::*;
+        // GCMGCMG with oxidation and carbamidomethylation would normally yield many variants;
+        // cap at 4 total (unmodified + 3 modified)
+        let variable_mods = [(Residue(b'M'), 16.0f32, None), (Residue(b'C'), 57.0, None)];
+        let peptide = Peptide::try_from(Digest {
+            sequence: "GCMGCMG".into(),
+            ..Default::default()
+        })
+        .unwrap();
+
+        let static_mods = HashMap::default();
+        let peptides: Vec<String> = peptide
+            .clone()
+            .apply(&variable_mods, &static_mods, 2, Some(4))
+            .into_iter()
+            .map(|p| p.to_string())
+            .collect();
+
+        // Cap at 4: unmodified + the first 3 single-mod variants (fewest PTMs first)
+        assert_eq!(peptides.len(), 4);
+        assert_eq!(peptides[0], "GCMGCMG");
     }
 
     #[test]
@@ -685,37 +774,221 @@ mod test {
         .unwrap();
 
         let mut mods = vec![];
-        peptide.push_resi(&mut mods, ModificationSpecificity::Residue(b'C'), 16.0);
-        assert_eq!(mods, vec![(Sequence(2), 16.0), (Sequence(5), 16.0)]);
+        peptide.push_resi(&mut mods, ModificationSpecificity::Residue(b'C'), 16.0, 0);
+        assert_eq!(mods, vec![(Sequence(2), 16.0, 0), (Sequence(5), 16.0, 0)]);
         mods.clear();
 
-        peptide.push_resi(&mut mods, ModificationSpecificity::PeptideC(None), 16.0);
-        assert_eq!(mods, vec![(Cterm, 16.0)]);
+        peptide.push_resi(&mut mods, ModificationSpecificity::PeptideC(None), 16.0, 0);
+        assert_eq!(mods, vec![(Cterm, 16.0, 0)]);
         mods.clear();
 
-        peptide.push_resi(&mut mods, ModificationSpecificity::PeptideN(None), 16.0);
-        assert_eq!(mods, vec![(Nterm, 16.0)]);
+        peptide.push_resi(&mut mods, ModificationSpecificity::PeptideN(None), 16.0, 0);
+        assert_eq!(mods, vec![(Nterm, 16.0, 0)]);
         mods.clear();
 
         let mut mods = vec![];
-        for (residue, mass) in [("^", 12.0), ("$", 200.0), ("C", 57.0), ("A", 43.0)] {
-            peptide.push_resi(&mut mods, residue.parse().unwrap(), mass);
+        for (idx, (residue, mass)) in [("^", 12.0), ("$", 200.0), ("C", 57.0), ("A", 43.0)]
+            .iter()
+            .enumerate()
+        {
+            peptide.push_resi(&mut mods, residue.parse().unwrap(), *mass, idx);
         }
 
         assert_eq!(
             mods,
             vec![
-                (Nterm, 12.0),
-                (Cterm, 200.0),
-                (Sequence(2), 57.0),
-                (Sequence(5), 57.0),
-                (Sequence(0), 43.0),
-                (Sequence(1), 43.0),
-                (Sequence(3), 43.0),
-                (Sequence(4), 43.0),
-                (Sequence(6), 43.0),
-                (Sequence(7), 43.0),
+                (Nterm, 12.0, 0),
+                (Cterm, 200.0, 1),
+                (Sequence(2), 57.0, 2),
+                (Sequence(5), 57.0, 2),
+                (Sequence(0), 43.0, 3),
+                (Sequence(1), 43.0, 3),
+                (Sequence(3), 43.0, 3),
+                (Sequence(4), 43.0, 3),
+                (Sequence(6), 43.0, 3),
+                (Sequence(7), 43.0, 3),
             ]
         );
+    }
+
+    #[test]
+    fn test_per_mod_limit_exactly_met() {
+        use ModificationSpecificity::*;
+        // Limit of 2 on a peptide with exactly 2 M residues — all combos should be allowed
+        let variable_mods = [(Residue(b'M'), 16.0f32, Some(2))];
+        let peptide = Peptide::try_from(Digest {
+            sequence: "GCMGCMG".into(),
+            ..Default::default()
+        })
+        .unwrap();
+
+        let static_mods = HashMap::default();
+        let peptides: Vec<String> = peptide
+            .clone()
+            .apply(&variable_mods, &static_mods, 2, None)
+            .into_iter()
+            .map(|p| p.to_string())
+            .collect();
+
+        // No restriction: unmodified + each single + double
+        let expected = vec![
+            "GCMGCMG",
+            "GCM[+16]GCMG",
+            "GCMGCM[+16]G",
+            "GCM[+16]GCM[+16]G",
+        ];
+        assert_eq!(peptides, expected);
+    }
+
+    #[test]
+    fn test_per_mod_limit_zero() {
+        use ModificationSpecificity::*;
+        // Limit of 0 means this mod is entirely suppressed
+        let variable_mods = [(Residue(b'M'), 16.0f32, Some(0))];
+        let peptide = Peptide::try_from(Digest {
+            sequence: "GCMGCMG".into(),
+            ..Default::default()
+        })
+        .unwrap();
+
+        let static_mods = HashMap::default();
+        let peptides: Vec<String> = peptide
+            .clone()
+            .apply(&variable_mods, &static_mods, 2, None)
+            .into_iter()
+            .map(|p| p.to_string())
+            .collect();
+
+        assert_eq!(peptides, vec!["GCMGCMG"]);
+    }
+
+    #[test]
+    fn test_mixed_limited_and_unlimited() {
+        use ModificationSpecificity::*;
+        // M oxidation limited to 1; C carbamidomethylation unlimited
+        // GCMGCMG has 2 M and 2 C
+        let variable_mods = [
+            (Residue(b'M'), 16.0f32, Some(1)),
+            (Residue(b'C'), 57.0f32, None),
+        ];
+        let peptide = Peptide::try_from(Digest {
+            sequence: "GCMGCMG".into(),
+            ..Default::default()
+        })
+        .unwrap();
+
+        let static_mods = HashMap::default();
+        let peptides: Vec<String> = peptide
+            .clone()
+            .apply(&variable_mods, &static_mods, 2, None)
+            .into_iter()
+            .map(|p| p.to_string())
+            .collect();
+
+        // Should include all combos with ≤1 oxidized M,
+        // but never both M residues oxidized simultaneously
+        for p in &peptides {
+            let oxid_count = p.matches("[+16]").count();
+            assert!(oxid_count <= 1, "too many oxidations in: {}", p);
+        }
+        // Both C residues carbamidomethylated simultaneously should be present
+        assert!(
+            peptides.contains(&"GC[+57]MGC[+57]MG".to_string()),
+            "expected double-C mod"
+        );
+        // Double oxidation should be absent
+        assert!(
+            !peptides.contains(&"GCM[+16]GCM[+16]G".to_string()),
+            "double oxidation should be suppressed"
+        );
+    }
+
+    #[test]
+    fn test_limits_are_per_mod_not_per_residue() {
+        use ModificationSpecificity::*;
+        // Both modifications target M, but only oxidation is limited to one.
+        let variable_mods = [
+            (Residue(b'M'), 16.0f32, Some(1)),
+            (Residue(b'M'), 32.0f32, None),
+        ];
+        let peptide = Peptide::try_from(Digest {
+            sequence: "GCMGCMG".into(),
+            ..Default::default()
+        })
+        .unwrap();
+
+        let peptides = peptide.apply(&variable_mods, &HashMap::default(), 2, None);
+        let peptides = peptides.iter().map(ToString::to_string).collect::<Vec<_>>();
+
+        assert!(!peptides.contains(&"GCM[+16]GCM[+16]G".to_string()));
+        assert!(peptides.contains(&"GCM[+32]GCM[+32]G".to_string()));
+    }
+
+    #[test]
+    fn test_limits_support_more_than_64_mod_entries() {
+        use ModificationSpecificity::*;
+        let mut variable_mods = (1..=65)
+            .map(|mass| (Residue(b'M'), mass as f32, None))
+            .collect::<Vec<_>>();
+        variable_mods[64].2 = Some(0);
+        let peptide = Peptide::try_from(Digest {
+            sequence: "GMG".into(),
+            ..Default::default()
+        })
+        .unwrap();
+
+        let peptides = peptide.apply(&variable_mods, &HashMap::default(), 1, None);
+
+        assert_eq!(peptides.len(), 65); // unmodified + 64 allowed entries
+        assert!(!peptides
+            .iter()
+            .any(|peptide| peptide.to_string().contains("[+65]")));
+    }
+
+    #[test]
+    fn test_max_combinations_only_unmodified() {
+        use ModificationSpecificity::*;
+        // cap of 1 means only the unmodified peptide is returned
+        let variable_mods = [(Residue(b'M'), 16.0f32, None)];
+        let peptide = Peptide::try_from(Digest {
+            sequence: "GCMGCMG".into(),
+            ..Default::default()
+        })
+        .unwrap();
+
+        let static_mods = HashMap::default();
+        let peptides: Vec<String> = peptide
+            .clone()
+            .apply(&variable_mods, &static_mods, 2, Some(1))
+            .into_iter()
+            .map(|p| p.to_string())
+            .collect();
+
+        assert_eq!(peptides, vec!["GCMGCMG"]);
+    }
+
+    #[test]
+    fn test_max_combinations_prefers_fewer_ptms() {
+        use ModificationSpecificity::*;
+        // GCMGCMG with oxidation (2 sites) — normally 3 variants (unmod + 2 single + 1 double)
+        // cap at 3 means we get unmod + both singles but not the double
+        let variable_mods = [(Residue(b'M'), 16.0f32, None)];
+        let peptide = Peptide::try_from(Digest {
+            sequence: "GCMGCMG".into(),
+            ..Default::default()
+        })
+        .unwrap();
+
+        let static_mods = HashMap::default();
+        let peptides: Vec<String> = peptide
+            .clone()
+            .apply(&variable_mods, &static_mods, 2, Some(3))
+            .into_iter()
+            .map(|p| p.to_string())
+            .collect();
+
+        assert_eq!(peptides, vec!["GCMGCMG", "GCM[+16]GCMG", "GCMGCM[+16]G"]);
+        // Double-mod must not appear — it would require cap > 3
+        assert!(!peptides.contains(&"GCM[+16]GCM[+16]G".to_string()));
     }
 }


### PR DESCRIPTION
## Summary

Adds optional per-modification occurrence limits and a cap on the total number
of variable-modification combinations generated for each peptide.

This implements the structured variable-modification format proposed in #231:

```json
"variable_mods": {
  "M": [
    {
      "mass": 15.9949,
      "max_count": 1
    }
  ]
}
```

Bare mass values remain supported for backward compatibility:

```json
"variable_mods": {
  "M": [15.9949]
}
```

The two formats can also be mixed within the same configuration.

## Changes

- Add structured variable-modification entries containing `mass` and optional `max_count`
- Add optional database-level `max_combinations`
- Preserve the existing `max_variable_mods` behavior
- Prefer variants with fewer modifications when applying the combination cap
- Preserve structured entries when serializing parameters to `results.json`
- Update documentation and changelog
- Add tests covering parsing, compatibility, limits, caps, and edge cases

`max_combinations` includes the unmodified peptide. A value of `0` is normalized
to `1`, matching the existing behavior of `max_variable_mods`.

Names, labile modifications, and neutral-loss configuration are intentionally
left for future work.

## Backward compatibility

Existing configurations using arrays of numeric masses continue to deserialize
and behave as before. When omitted:

- `max_count` remains unlimited
- `max_combinations` remains unlimited
- `max_variable_mods` retains its existing default and behavior

## Validation

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets`
- `cargo test --workspace` — 108 tests passed
- Release build
- End-to-end CLI searches using both structured and legacy configurations
- Verified structured configuration round-trips through `results.json`

Addresses #231.
